### PR TITLE
Code cleanup, and fixups to draft4 support

### DIFF
--- a/python_jsonschema_objects/__init__.py
+++ b/python_jsonschema_objects/__init__.py
@@ -71,13 +71,11 @@ class ObjectBuilder(object):
 
     def build_classes(self):
         builder = classbuilder.ClassBuilder(self.resolver)
-        for k, v in iteritems(self.schema):
-            if k == 'definitions':
-                for nm, defn in iteritems(v):
-                    uri = util.resolve_ref_uri(
-                        self.resolver.resolution_scope,
-                        "#/definitions/" + nm)
-                    builder.construct(uri, defn)
+        for nm, defn in iteritems(self.schema.get('definitions', {})):
+            uri = util.resolve_ref_uri(
+                self.resolver.resolution_scope,
+                "#/definitions/" + nm)
+            builder.construct(uri, defn)
 
         nm = self.schema['title'] if 'title' in self.schema else self.schema['id']
         nm = inflection.parameterize(six.text_type(nm), '_')

--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -565,13 +565,19 @@ def make_property(prop, info, desc=""):
         if isinstance(info['type'], (list, tuple)):
             ok = False
             errors = []
+            type_checks = []
             for typ in info['type']:
-                if isinstance(typ, dict):
-                    typ = ProtocolBase.__SCHEMA_TYPES__[typ['type']]
-                    if typ == None:
-                        typ = type(None)
-                    ok = True
-                    break
+              if not isinstance(typ, dict):
+                type_checks.append(typ)
+                continue
+              typ = ProtocolBase.__SCHEMA_TYPES__[typ['type']]
+              if typ == None:
+                typ = type(None)
+              if isinstance(typ, (list, tuple)):
+                type_checks.extend(typ)
+              else:
+                type_checks.append(typ)
+            for typ in type_checks:
                 if isinstance(val, typ):
                     ok = True
                     break

--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -348,7 +348,7 @@ class ClassBuilder(object):
 
             return self.resolved[uri]
 
-        elif 'array' in clsdata and 'items' in clsdata:
+        elif clsdata.get('type') == 'array' and 'items' in clsdata:
             self.resolved[uri] = self._build_object(
                 uri,
                 clsdata,

--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -42,7 +42,7 @@ class ProtocolBase( collections.MutableMapping):
 
     def __repr__(self):
         inverter = dict((v, k) for k,v in six.iteritems(self.__prop_names__))
-        props = ["%s=%s" % (inverter[k], str(v)) for k, v in
+        props = ["%s=%s" % (inverter.get(k, k), str(v)) for k, v in
                  itertools.chain(six.iteritems(self._properties),
                                  six.iteritems(self._extended_properties))]
         return "<%s %s>" % (

--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -58,22 +58,22 @@ class ProtocolBase( collections.MutableMapping):
       obj.validate()
       return obj
 
-    def __init__(this, **props):
-        this._extended_properties = dict()
-        this._properties = dict(zip(this.__prop_names__.values(),
+    def __init__(self, **props):
+        self._extended_properties = dict()
+        self._properties = dict(zip(self.__prop_names__.values(),
                                     [None for x in
-                                     six.moves.xrange(len(this.__prop_names__))]))
+                                     six.moves.xrange(len(self.__prop_names__))]))
 
         for prop in props:
 
             try:
               logging.debug("Setting value for '{0}' to {1}"
                             .format(prop, props[prop]))
-              setattr(this, prop, props[prop])
+              setattr(self, prop, props[prop])
             except validators.ValidationError as e:
               import sys
               raise six.reraise(type(e), type(e)(str(e) + " \nwhile setting '{0}' in {1}".format(
-                  prop, this.__class__.__name__)), sys.exc_info()[2])
+                  prop, self.__class__.__name__)), sys.exc_info()[2])
 
         #if len(props) > 0:
         #    this.validate()
@@ -555,13 +555,13 @@ class ClassBuilder(object):
 
 def make_property(prop, info, desc=""):
 
-    def getprop(this):
+    def getprop(self):
         try:
-            return this._properties[prop]
+            return self._properties[prop]
         except KeyError:
             raise AttributeError("No such attribute")
 
-    def setprop(this, val):
+    def setprop(self, val):
         if isinstance(info['type'], (list, tuple)):
             ok = False
             errors = []
@@ -625,12 +625,12 @@ def make_property(prop, info, desc=""):
         else:
             raise TypeError("Unknown object type: '{0}'".format(info['type']))
 
-        this._properties[prop] = val
+        self._properties[prop] = val
 
-    def delprop(this):
-        if prop in this.__required__:
+    def delprop(self):
+        if prop in self.__required__:
             raise AttributeError("'%s' is required" % prop)
         else:
-            del this._properties[prop]
+            del self._properties[prop]
 
     return property(getprop, setprop, delprop, desc)

--- a/python_jsonschema_objects/validators.py
+++ b/python_jsonschema_objects/validators.py
@@ -4,8 +4,6 @@ import six
 class ValidationError(Exception):
     pass
 
-klassType = type
-
 
 def multipleOf(param, value):
     quot, rem = divmod(value, param)
@@ -13,16 +11,6 @@ def multipleOf(param, value):
         raise ValidationError(
             "{0} was not a multiple of {1}".format(value,
                                                    param))
-
-
-def type(param, value):
-    from python_jsonschema_objects import classbuilder
-    if isinstance(param, six.string_types):
-        param = classbuilder.ProtocolBase.__SCHEMA_TYPES__[param]
-    if not isinstance(value, param):
-        raise ValidationError(
-            "'{0}' was not an instance of {1}".format(value, param))
-
 
 def enum(param, value):
     if value not in param:
@@ -191,7 +179,7 @@ class ArrayValidator(object):
                             "Item constraint (position {0}) was not a schema".format(i))
             else:
                 isdict = isinstance(item_constraint, (dict,))
-                isklass = isinstance( item_constraint, klassType) and issubclass(
+                isklass = isinstance( item_constraint, type) and issubclass(
                     item_constraint, (classbuilder.ProtocolBase, classbuilder.LiteralValue))
 
                 if not any([isdict, isklass]):
@@ -207,7 +195,7 @@ class ArrayValidator(object):
 
         props.update(addl_constraints)
 
-        validator = klassType(str(name), (ArrayValidator,), props)
+        validator = type(str(name), (ArrayValidator,), props)
 
         return validator
 

--- a/python_jsonschema_objects/validators.py
+++ b/python_jsonschema_objects/validators.py
@@ -137,9 +137,13 @@ class ArrayValidator(object):
                 typed_elems.append(val)
             elif issubclass(typ, classbuilder.ProtocolBase):
                 if not isinstance(elem, typ):
+                    data = elem
+                    if hasattr(data, 'as_dict'):
+                        # abc.meta objects can't be used for **; get the raw dict.
+                        data = elem.as_dict()
                     try:
-                      val = typ(**elem)
-                    except TypeError:
+                      val = typ(**data)
+                    except TypeError, e:
                       raise ValidationError("'{0}' was not a valid value for '{1}'".format(elem, typ))
                 else:
                     val = elem


### PR DESCRIPTION
Beyond some basic naggles being fixed, the following core support features were fixed:

*) type="array" check assumed that the type was specified via array key; it's controlled via type="array".
*) When instantiating an instance from pre-existing json data, if passed a preexisitng psj object the logic internally would fail- it would try to do keywords expansion on an abc.meta instance (literally, **my_instance).  In py3k this may be supported, but in py2.7 only dictionaries can be expanded in such a fashion.
*) oneOf (and friends) validation checks were silently exiting out without performing validation.  Minor oversight pretty much, although my suspicion is that the code pathway treats anyOf/allOf/oneOf all as anyOf.