### PR TITLE
Add in support for long (instead of just int/float), and add a .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,58 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -4,10 +4,14 @@ import python_jsonschema_objects.validators as validators
 import collections
 import itertools
 import six
+import sys
 
 import logging
 logger = logging.getLogger(__name__)
 
+# Long is no longer a thing in python3.x
+if sys.version_info > (3,):
+  long = int
 
 class ProtocolBase( collections.MutableMapping):
     __propinfo__ = {}
@@ -17,7 +21,7 @@ class ProtocolBase( collections.MutableMapping):
         'array': list,
         'boolean': bool,
         'integer': int,
-        'number': (float, int),
+        'number': (float, int, long),
         'null': None,
         'string': six.string_types,
         'object': dict


### PR DESCRIPTION
Pretty simple, but the jsonschema spec says that 'numbers' are any valid integer/float/long/double/whatever. 

Also I had to add in some compatibility fixes for Python3. All tests pass. 