### PR TITLE
Fixing issue where you can lose underscore properties when you have a…

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -16,6 +16,7 @@ if sys.version_info > (3,):
 class ProtocolBase( collections.MutableMapping):
     __propinfo__ = {}
     __required__ = set()
+    __object_attr_list__ = set(["_properties", "_extended_properties"])
 
     __SCHEMA_TYPES__ = {
         'array': list,
@@ -86,7 +87,7 @@ class ProtocolBase( collections.MutableMapping):
         #    this.validate()
 
     def __setattr__(self, name, val):
-        if name.startswith("_"):
+        if name in self.__object_attr_list__:
             object.__setattr__(self, name, val)
         elif name in self.__propinfo__:
             # If its in __propinfo__, then it actually has a property defined.

--- a/test/test.py
+++ b/test/test.py
@@ -14,6 +14,32 @@ import nose
 import pkg_resources
 import python_jsonschema_objects as pjs
 
+describe TestCase, 'underscore properties':
+
+    it 'underscore properties should not be lost':
+        import python_jsonschema_objects
+        schema = {
+                "$schema": "http://json-schema.org/schema#",
+                "title": "AggregateQuery",
+                "type": "object",
+                "properties": {
+                    "group": {
+                        "type": "object",
+                        "properties": {}
+                    }
+                }
+                }
+        builder = python_jsonschema_objects.ObjectBuilder(schema)
+        ns = builder.build_classes()
+        my_obj_type = ns.Aggregatequery
+        request_object = my_obj_type(
+            group={
+                "_id": { "foo_id": "$foo_id", "foo_type": "$foo_type" },
+                "foo": { "$sum": 1 },
+            }
+        )
+        request_object.group._extended_properties.should.contain("_id")
+
 describe TestCase, 'regression #9':
 
     it 'should not throw an error':
@@ -230,3 +256,4 @@ describe TestCase, 'markdown extraction':
                 person = self.Person( **pdict)
 
                 person.as_dict().should.equal(pdict)
+


### PR DESCRIPTION
… general schema (where properties are stored in _extended_properties).

@cwacek: from what I could understand this piece of code:
```python
if name.startswith("_"):
    # set attr
```
was needed for handling the special attributes **_properties** and **_extended_properties**.  However it had adverse effects if you tried to have underscore prefixed fields.  This fixed the issue and didn't break any existing tests, but let me know if you think there is a better way to approach this problem.