### PR TITLE
Improve error message for missing required attributes

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -162,7 +162,7 @@ class ProtocolBase( collections.MutableMapping):
         if len(missing) > 0:
             raise validators.ValidationError(
                 "'{0}' are required attributes for {1}"
-                            .format(missing, self.__class__))
+                            .format(missing, self.__class__.__name__))
 
         for prop, val in six.iteritems(self._properties):
             if val is None:


### PR DESCRIPTION
Hi!
I'd like to propose a little patch to improve a bit error message for missing attributes, so ugly
> ValidationError: '['id', 'type']' are required attributes for \<class 'abc.resource'>

becomes neat

> ValidationError: '['id', 'type']' are required attributes for resource