### PR TITLE
added a way to fetch a class by ref URI

### DIFF
--- a/python_jsonschema_objects/__init__.py
+++ b/python_jsonschema_objects/__init__.py
@@ -47,12 +47,19 @@ class ObjectBuilder(object):
                                          resolver=self.resolver)
 
         self._classes = None
+        self._resolved = None
 
     @property
     def classes(self):
         if self._classes is None:
           self._classes = self.build_classes()
         return self._classes
+
+    def get_class(self, uri):
+        if self._resolved is None:
+          self._classes = self.build_classes()
+        return self._resolved.get(uri, None)
+
 
     def memory_resolver(self, uri):
         return self.mem_resolved[uri[7:]]
@@ -81,6 +88,7 @@ class ObjectBuilder(object):
         nm = inflection.parameterize(six.text_type(nm), '_')
 
         builder.construct(nm, self.schema)
+        self._resolved = builder.resolved
 
         return (
             util.Namespace.from_mapping(dict(


### PR DESCRIPTION
This will allow a user to find a class in an `ObjectBuilder` instance if all they have is a ref URI. A good use case is illustrated in the [JSON Schema docs](http://json-schema.org/latest/json-schema-core.html#anchor34). When talking to an API that returns the 'profile' MIME type parameter to the Content-Type header, you can now pass the URI from that parameter to `ObjectBuilder.get_class`, and get a class that can be populated with the API response.