### PR TITLE
use logger instead of logging in the class_builder

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -75,7 +75,7 @@ class ProtocolBase( collections.MutableMapping):
         for prop in props:
 
             try:
-              logging.debug("Setting value for %s' to %s", prop, props[prop])
+              logger.debug("Setting value for %s' to %s", prop, props[prop])
               setattr(self, prop, props[prop])
             except validators.ValidationError as e:
               import sys
@@ -330,13 +330,13 @@ class ClassBuilder(object):
                     clsdata['type'], (ProtocolBase, LiteralValue)):
                 # It's possible that this reference was already resolved, in which
                 # case it will have its type parameter set
-                logging.debug("Using previously resolved type "
+                logger.debug("Using previously resolved type "
                               "(with different URI) for %s", uri)
                 self.resolved[uri] = clsdata['type']
             elif uri in self.resolved:
-                logging.debug("Using previously resolved object for %s", uri)
+                logger.debug("Using previously resolved object for %s", uri)
             else:
-                logging.debug("Resolving object for %s", uri)
+                logger.debug("Resolving object for %s", uri)
 
                 with self.resolver.resolving(uri) as resolved:
                     self.resolved[uri] = None # Set incase there is a circular reference in schema definition


### PR DESCRIPTION
There are few places in classbuilder whcih logging is used
instead of logger.

The side effect of using the logging was that the user of this library
could not enitely mask the debug logs of python_jsonschema

with this change the user can now set the logging level for this
library by calling setLevel