### PR TITLE
Handle the case where user sets value of anonymous property to None

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -107,14 +107,16 @@ class ProtocolBase( collections.MutableMapping):
                 # Pick the type based on the type of the values
                 valtype = [k for k, t in six.iteritems(self.__SCHEMA_TYPES__)
                            if t is not None and isinstance(val, t)]
-                valtype = valtype[0]
-                val = MakeLiteral(name, valtype, val)
+                if valtype:
+                    valtype = valtype[0]
+                    val = MakeLiteral(name, valtype, val)
             elif isinstance(typ, type) and getattr(typ, 'isLiteralClass', None) is True:
                 val = typ(val)
             elif isinstance(typ, type) and util.safe_issubclass(typ, ProtocolBase):
                 val = typ(**util.coerce_for_expansion(val))
 
-            self._extended_properties[name] = val
+            if val:
+                self._extended_properties[name] = val
 
     """ Implement collections.MutableMapping methods """
 


### PR DESCRIPTION
if a property is not defined in the schema and user
attempts to set the value to None the object creation
fails with because classbuild is not able to detect
the type of that property. In this case we can skip
setting the value for this property.

e.g if Disease type does not have a 'name' property
disease.name = None will raise an exception but
disease.name = 'Cold' will go through even though
name is not a valid property in the schema.
If classbuild let the caller set the value for an
anynomous property then the user should be able to
also set the value to empty or none

exception which was raised before this patch:

  File "python_jsonschema_objects/classbuilder.py", line 110, in __setattr__
    valtype = valtype[0]
IndexError: list index out of range

tox test result:

33 tests run in 0.5 seconds (33 tests passed)
py35 runtests: commands[1] | coverage html --omit=*test* --include=*python_jsonschema_objects*
___________________________________________________________ summary ___________________________________________________________
  py27: commands succeeded
  py35: commands succeeded
  congratulations :)