### PR TITLE
bugfix: Fixes #35 and adds a test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ For example, given the following schema:
             "items": {"type": "string"},
             "maxItems": 4
         },
+        "address": {
+            "type": "object",
+            "properties": {
+                "street": {"type": "string"},
+                "city": {"type": "string"},
+                "state": {"type": "string"}
+                },
+            "required":["street", "city"]
+            },
         "gender": {
             "type": "string",
             "enum": ["male", "female"]

--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -34,10 +34,10 @@ class ProtocolBase( collections.MutableMapping):
 
             if isinstance(propval, list):
                 out[prop] = [getattr(x, 'as_dict', lambda :x)() for x in propval]
-            elif not isinstance(propval, LiteralValue) and propval is not None:
-                out[prop] = propval
-            elif propval is not None:
+            elif isinstance(propval, ProtocolBase):
                 out[prop] = propval.as_dict()
+            elif propval is not None:
+                out[prop] = propval
 
         return out
 

--- a/test/test.py
+++ b/test/test.py
@@ -220,13 +220,32 @@ describe TestCase, 'markdown extraction':
                       }
                     )
 
-            it 'should transform into dictionaries recursively"':
-                pdict = dict(
-                        firstName="James",
-                        lastName="Bond",
-                        dogs=["Lassie", "Bobo"]
-                        )
+            describe 'dictionary transformation':
 
-                person = self.Person( **pdict)
+                it 'should work for nested arrays':
+                    pdict = dict(
+                            firstName="James",
+                            lastName="Bond",
+                            dogs=["Lassie", "Bobo"]
+                            )
 
-                person.as_dict().should.equal(pdict)
+                    person = self.Person( **pdict)
+
+                    person.as_dict().should.equal(pdict)
+
+                it 'should work for nested objects':
+                    pdict = dict(
+                            firstName="James",
+                            lastName="Bond",
+                            address={
+                                "street": "10 Example Street",
+                                "city": "Springfield",
+                                "state": "USA"
+                            },
+                            dogs=["Lassie", "Bobo"]
+                            )
+
+                    person = self.Person( **pdict)
+
+                    out_pdict = person.as_dict()
+                    out_pdict.should.equal(pdict)


### PR DESCRIPTION
There was an issue in the as_dict method of protocol base
where it wasn't ever explicitly checking for subclasses
of ProtocolBase and calling as_dict for them. This makes
the check explicity, rather than implicit (by checking for other
conditions or the existence of 'as_dict')