### PR TITLE
Construct array item references.

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -419,7 +419,7 @@ class ClassBuilder(object):
 
                 with self.resolver.resolving(uri) as resolved:
                     self.resolved[uri] = None # Set incase there is a circular reference in schema definition
-                    self.resolved[uri] = self._build_object(
+                    self.resolved[uri] = self.construct(
                         uri,
                         resolved,
                         parent)


### PR DESCRIPTION
When array items are references to another schema, we must allow for the
possibility that we need to resolve additional references for an `allOf`
definition. As such, we call `construct()` rather than
`_build_object()`.

This is a fix for #39.