### PR TITLE
Allow long number type.

### DIFF
--- a/python_jsonschema_objects/validators.py
+++ b/python_jsonschema_objects/validators.py
@@ -117,9 +117,9 @@ def check_integer_type(param, value, _):
 
 @type_registry.register(name='number')
 def check_number_type(param, value, _):
-    if not isinstance(value, (float, int)) or isinstance(value, bool):
+    if not isinstance(value, (float, int, long)) or isinstance(value, bool):
         raise ValidationError(
-            "{0} is neither an integer or a float".format(value))
+            "{0} is neither an integer, float, or long".format(value))
 
 @type_registry.register(name='null')
 def check_null_type(param, value, _):

--- a/python_jsonschema_objects/validators.py
+++ b/python_jsonschema_objects/validators.py
@@ -119,7 +119,7 @@ def check_integer_type(param, value, _):
 def check_number_type(param, value, _):
     if not isinstance(value, six.integer_types + (float,)) or isinstance(value, bool):
         raise ValidationError(
-            "{0} is neither an integer nor a long".format(value))
+            "{0} is neither an integer nor a float".format(value))
 
 @type_registry.register(name='null')
 def check_null_type(param, value, _):

--- a/python_jsonschema_objects/validators.py
+++ b/python_jsonschema_objects/validators.py
@@ -119,7 +119,7 @@ def check_integer_type(param, value, _):
 def check_number_type(param, value, _):
     if not isinstance(value, (float, int, long)) or isinstance(value, bool):
         raise ValidationError(
-            "{0} is neither an integer, float, or long".format(value))
+            "{0} is neither an integer, float, nor long".format(value))
 
 @type_registry.register(name='null')
 def check_null_type(param, value, _):

--- a/python_jsonschema_objects/validators.py
+++ b/python_jsonschema_objects/validators.py
@@ -117,9 +117,9 @@ def check_integer_type(param, value, _):
 
 @type_registry.register(name='number')
 def check_number_type(param, value, _):
-    if not isinstance(value, (float, int, long)) or isinstance(value, bool):
+    if not isinstance(value, six.integer_types + (float,)) or isinstance(value, bool):
         raise ValidationError(
-            "{0} is neither an integer, float, nor long".format(value))
+            "{0} is neither an integer nor a long".format(value))
 
 @type_registry.register(name='null')
 def check_null_type(param, value, _):


### PR DESCRIPTION
The `long` type is a valid Python numeric type. Allow it when checking
`number` types.