### PR TITLE
Make property setting robust to inheritance.

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -178,7 +178,7 @@ class ProtocolBase(collections.MutableMapping):
             # The property does special validation, so we actually need to
             # run its setter. We get it from the class definition and call
             # it directly. XXX Heinous.
-            prop = self.__class__.__dict__[self.__prop_names__[name]]
+            prop = getattr(self.__class__, self.__prop_names__[name])
             prop.fset(self, val)
         else:
             # This is an additional property of some kind


### PR DESCRIPTION
Use `getattr(self.__class__, property_name)` to get properties and set
them. This is compatible with using a class builder as a base class. In
my case, I'm extending class builders so that I can add constants for
enum values directly to the class definition rather than having to use
strings.