### PR TITLE
feature: Adds support for patternProperties

### DIFF
--- a/python_jsonschema_objects/pattern_properties.py
+++ b/python_jsonschema_objects/pattern_properties.py
@@ -1,0 +1,104 @@
+
+import six
+import re
+import python_jsonschema_objects.validators as validators
+import python_jsonschema_objects.util as util
+import collections
+
+import logging
+logger = logging.getLogger(__name__)
+
+PatternDef = collections.namedtuple('PatternDef', 'pattern schema_type')
+
+
+class ExtensibleValidator(object):
+
+    def __init__(self, name, schemadef, builder):
+        import python_jsonschema_objects.classbuilder as cb
+
+        self._pattern_types = []
+        self._additional_type = True
+
+        addlProp = schemadef.get('additionalProperties', True)
+
+        if addlProp is False:
+            self._additional_type = False
+        elif addlProp is True:
+            self._additional_type = True
+        else:
+            if '$ref' in addlProp:
+                refs = builder.resolve_classes([addlProp])
+            else:
+                uri = "{0}/{1}_{2}".format(
+                    name,
+                    "<additionalProperties>", "<anonymous>")
+                builder.resolved[uri] = builder.construct(
+                    uri,
+                    addlProp,
+                    (cb.ProtocolBase,))
+                refs = [builder.resolved[uri]]
+
+            self._additional_type = refs[0]
+
+        for pattern, typedef in six.iteritems(
+                schemadef.get('patternProperties', {})):
+            if '$ref' in typedef:
+                refs = builder.resolve_classes([typedef])
+            else:
+                uri = "{0}/{1}_{2}".format(name,
+                                           "<patternProperties>",
+                                           pattern)
+
+                builder.resolved[uri] = builder.construct(
+                    uri,
+                    typedef,
+                    (cb.ProtocolBase,))
+                refs = [builder.resolved[uri]]
+
+            self._pattern_types.append(PatternDef(
+                pattern=re.compile(pattern),
+                schema_type=refs[0]
+            ))
+
+    def _make_type(self, typ, val):
+        import python_jsonschema_objects.classbuilder as cb
+
+        if getattr(
+               typ, 'isLiteralClass', None) is True:
+            return typ(val)
+
+        if util.safe_issubclass(typ, cb.ProtocolBase):
+            return typ(**util.coerce_for_expansion(val))
+
+        if util.safe_issubclass(typ, validators.ArrayValidator):
+            return typ(val)
+
+        raise validators.ValidationError(
+            "additionalProperty type {0} was neither a literal "
+            "nor a schema wrapper: {1}".format(typ, val))
+
+    def instantiate(self, name, val):
+        import python_jsonschema_objects.classbuilder as cb
+
+        for p in self._pattern_types:
+            if p.pattern.search(name):
+                logger.debug(
+                    "Found patternProperties match: %s %s" % (
+                        p.pattern.pattern, name
+                    ))
+                return self._make_type(p.schema_type, val)
+
+        if self._additional_type is True:
+
+            valtype = [k for k, t
+                       in six.iteritems(validators.SCHEMA_TYPE_MAPPING)
+                       if t is not None and isinstance(val, t)]
+            valtype = valtype[0]
+            return cb.MakeLiteral(name, valtype, val)
+
+        elif isinstance(self._additional_type, type):
+            return self._make_type(self._additional_type, val)
+
+        raise validators.ValidationError(
+            "additionalProperties not permitted "
+            "and no patternProperties specified")

--- a/python_jsonschema_objects/validators.py
+++ b/python_jsonschema_objects/validators.py
@@ -4,9 +4,20 @@ import collections
 import logging
 logger = logging.getLogger(__name__)
 
+SCHEMA_TYPE_MAPPING = {
+    'array': list,
+    'boolean': bool,
+    'integer': six.integer_types,
+    'number': six.integer_types + (float,),
+    'null': type(None),
+    'string': six.string_types,
+    'object': dict
+}
+
 
 class ValidationError(Exception):
     pass
+
 
 class ValidatorRegistry(object):
 

--- a/test/test_pattern_properties.py
+++ b/test/test_pattern_properties.py
@@ -1,0 +1,74 @@
+import pytest
+
+import python_jsonschema_objects as pjo
+import json
+
+
+@pytest.fixture
+def base_schema():
+    return {
+        'title': 'example',
+        'type': 'object',
+        "properties": {
+            'foobar': {"type": "boolean"}
+        },
+        "patternProperties": {
+            "^foo.*": {
+                "type": "string"
+            },
+            "^bar.*": {
+                "type": "integer"
+            }
+        }
+    }
+
+
+def test_standard_properties_take_precedence(base_schema):
+    """ foobar is a boolean, and it's a standard property,
+    so we expect it will validate properly as a boolean,
+    not using the patternProperty that matches it.
+    """
+    builder = pjo.ObjectBuilder(base_schema)
+    ns = builder.build_classes()
+
+    t = ns.Example(foobar=True)
+    t.validate()
+
+    with pytest.raises(pjo.ValidationError):
+        # Try against the foo pattern
+        x = ns.Example(foobar="hi")
+        x. validate()
+
+
+@pytest.mark.parametrize('permit_addl,property,value,is_error',[
+    (False, 'foo', 'hello', False),
+    (False, 'foobarro', 'hello', False),
+    (False, 'foo', 24, True),
+    (False, 'barkeep', 24, False),
+    (False, 'barkeep', "John", True),
+    (False, 'extraprop', "John", True),
+    (True, 'extraprop', "John", False),
+    # Test that the pattern props take precedence.
+    # because these should validate against them, not the
+    # additionalProperties that match
+    (True, 'foobar', True, False),
+    (True, 'foobar', "John", True),
+    (True, 'foobar', 24, True),
+])
+def test_pattern_properties_work(
+        base_schema, permit_addl, property, value, is_error):
+
+    base_schema['additionalProperties'] = permit_addl
+
+    builder = pjo.ObjectBuilder(base_schema)
+    ns = builder.build_classes()
+
+    props = dict([(property, value)])
+
+    if is_error:
+        with pytest.raises(pjo.ValidationError):
+            t = ns.Example(**props)
+            t.validate()
+    else:
+        t = ns.Example(**props)
+        t.validate()


### PR DESCRIPTION
This adds support for patternProperties by replacing the
multi-valued __extensible__ flag with a new ExtensibleValidator class
that handles all "extensibility" functionality, including
additionalProperties and patternProperties.

This also adds a bunch of tests to validate this functionality
(and that the resolution order is correct).

Fixes #44