### PR TITLE
Support boolean in schema child object.

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -685,7 +685,9 @@ def make_property(prop, info, desc=""):
               if not isinstance(typ, dict):
                 type_checks.append(typ)
                 continue
-              typ = validators.SCHEMA_TYPE_MAPPING[typ['type']]
+              typ = next(t
+                         for n, t in validators.SCHEMA_TYPE_MAPPING
+                         if typ['type'] == t)
               if typ is None:
                   typ = type(None)
               if isinstance(typ, (list, tuple)):

--- a/python_jsonschema_objects/pattern_properties.py
+++ b/python_jsonschema_objects/pattern_properties.py
@@ -91,7 +91,7 @@ class ExtensibleValidator(object):
         if self._additional_type is True:
 
             valtype = [k for k, t
-                       in six.iteritems(validators.SCHEMA_TYPE_MAPPING)
+                       in validators.SCHEMA_TYPE_MAPPING
                        if t is not None and isinstance(val, t)]
             valtype = valtype[0]
             return cb.MakeLiteral(name, valtype, val)

--- a/python_jsonschema_objects/validators.py
+++ b/python_jsonschema_objects/validators.py
@@ -4,15 +4,16 @@ import collections
 import logging
 logger = logging.getLogger(__name__)
 
-SCHEMA_TYPE_MAPPING = {
-    'array': list,
-    'boolean': bool,
-    'integer': six.integer_types,
-    'number': six.integer_types + (float,),
-    'null': type(None),
-    'string': six.string_types,
-    'object': dict
-}
+SCHEMA_TYPE_MAPPING = (
+    ('array', list),
+    ('boolean', bool),
+    ('integer', six.integer_types),
+    ('number', six.integer_types + (float,)),
+    ('null', type(None)),
+    ('string', six.string_types),
+    ('object', dict),
+)
+"""Sequence of schema type mappings to be checked in precedence order."""
 
 
 class ValidationError(Exception):

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -400,3 +400,21 @@ def test_strict_mode():
         ns = builder.build_classes(strict=True)
         NameData = ns.NameData
         NameData(lastName="hello")
+
+
+def test_boolean_in_child_object():
+    schema = {
+        "$schema": "http://json-schema.org/schema#",
+        "id": "test",
+        "type": "object",
+        "properties": {
+            "data": {
+                "type": "object",
+                "additionalProperties": True
+            }
+        }
+    }
+    builder = pjs.ObjectBuilder(schema)
+    ns = builder.build_classes()
+
+    ns.Test(data={"my_bool": True})


### PR DESCRIPTION
Type checking has precedence since `isinstance(True, int) == True` in
Python. Convert schema mappings to sequence of tuples instead of `dict`
to maintain precedence during type checking.