### PR TITLE
feature: Use jsonschema to validate the schema itself before load

### DIFF
--- a/python_jsonschema_objects/__init__.py
+++ b/python_jsonschema_objects/__init__.py
@@ -43,8 +43,11 @@ class ObjectBuilder(object):
             }
         )
 
+        meta_validator = Draft4Validator(Draft4Validator.META_SCHEMA)
+        meta_validator.validate(self.schema)
         self.validator = Draft4Validator(self.schema,
                                          resolver=self.resolver)
+
 
         self._classes = None
         self._resolved = None

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -2,11 +2,28 @@ import pytest
 
 import json
 import six
-import pkg_resources
+import jsonschema
 import python_jsonschema_objects as pjs
 
 import logging
 logging.basicConfig(level=logging.DEBUG)
+
+
+def test_schema_validation():
+    """ Test that the ObjectBuilder validates the schema itself.
+    """
+    schema = {
+        "$schema": "http://json-schema.org/schema#",
+        "id": "test",
+        "type": "object",
+        "properties": {
+                "name": "string",
+                "email": {"oneOf": [{"type": "string"}, {"type": "integer"}]},
+        },
+        "required": ["email"]
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        pjs.ObjectBuilder(schema)
 
 
 def test_regression_9():
@@ -16,7 +33,7 @@ def test_regression_9():
         "type": "object",
         "properties": {
                 "name": {"type": "string"},
-                "email": {"oneOf": ["string", "integer"]},
+                "email": {"oneOf": [{"type": "string"}, {"type": "integer"}]},
         },
         "required": ["email"]
     }

--- a/test/test_regression_17.py
+++ b/test/test_regression_17.py
@@ -12,7 +12,6 @@ def test_class():
                 "id": "claimed",
                 "type": ["string", "integer", "null"],
                 "description": "Robots Only. The human agent that has claimed this robot.",
-                "required": False
                 },
             }
         }


### PR DESCRIPTION
If the schema isn't valid, the error messages from this library are inscrutable.
Solution: check the schema before trying to load it