### PR TITLE
bugfix: Resolve the correct reference type for objects

### DIFF
--- a/python_jsonschema_objects/__init__.py
+++ b/python_jsonschema_objects/__init__.py
@@ -3,6 +3,7 @@ from jsonschema import Draft4Validator
 from jsonschema.compat import iteritems
 import json
 import codecs
+import copy
 import os.path
 import inflection
 import six
@@ -51,6 +52,17 @@ class ObjectBuilder(object):
 
         self._classes = None
         self._resolved = None
+
+    @property
+    def schema(self):
+        try:
+            return copy.deepcopy(self._schema)
+        except AttributeError:
+            raise ValidationError("No schema provided")
+
+    @schema.setter
+    def schema(self, val):
+        setattr(self, '_schema', val)
 
     @property
     def classes(self):

--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -437,6 +437,8 @@ class ClassBuilder(object):
             return self.resolved[uri]
 
         elif '$ref' in clsdata:
+            ref_uri = clsdata['$ref']
+            logger.debug(util.lazy_format("Resolving object for {0} ($ref: {1})", uri, ref_uri))
 
             if 'type' in clsdata and util.safe_issubclass(
                     clsdata['type'], (ProtocolBase, LiteralValue)):
@@ -446,11 +448,11 @@ class ClassBuilder(object):
                               "(with different URI) for {0}", uri))
                 self.resolved[uri] = clsdata['type']
             elif uri in self.resolved:
-                logger.debug(util.lazy_format("Using previously resolved object for {0}", uri))
+                logger.debug(util.lazy_format("Using previously resolved object for {0}", ref_uri))
             else:
-                logger.debug(util.lazy_format("Resolving object for {0}", uri))
+                logger.debug(util.lazy_format("Resolving object for {0}", ref_uri))
 
-                with self.resolver.resolving(uri) as resolved:
+                with self.resolver.resolving(ref_uri) as resolved:
                     self.resolved[uri] = None # Set incase there is a circular reference in schema definition
                     self.resolved[uri] = self.construct(
                         uri,

--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -536,6 +536,7 @@ class ClassBuilder(object):
         name_translation = {}
 
         for prop, detail in properties.items():
+            logger.debug(util.lazy_format("Handling property {0}.{1}",nm, prop))
             properties[prop]['raw_name'] = prop
             name_translation[prop] = prop.replace('@', '')
             prop = name_translation[prop]
@@ -556,6 +557,9 @@ class ClassBuilder(object):
             elif 'type' not in detail and '$ref' in detail:
                 ref = detail['$ref']
                 uri = util.resolve_ref_uri(self.resolver.resolution_scope, ref)
+                logger.debug(util.lazy_format("Resolving reference {0} for {1}.{2}",
+                    ref, nm, prop
+                    ))
                 if uri not in self.resolved:
                     with self.resolver.resolving(ref) as resolved:
                         self.resolved[uri] = self.construct(

--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -437,8 +437,6 @@ class ClassBuilder(object):
             return self.resolved[uri]
 
         elif '$ref' in clsdata:
-            ref_uri = clsdata['$ref']
-            logger.debug(util.lazy_format("Resolving object for {0} ($ref: {1})", uri, ref_uri))
 
             if 'type' in clsdata and util.safe_issubclass(
                     clsdata['type'], (ProtocolBase, LiteralValue)):
@@ -448,11 +446,11 @@ class ClassBuilder(object):
                               "(with different URI) for {0}", uri))
                 self.resolved[uri] = clsdata['type']
             elif uri in self.resolved:
-                logger.debug(util.lazy_format("Using previously resolved object for {0}", ref_uri))
+                logger.debug(util.lazy_format("Using previously resolved object for {0}", uri))
             else:
-                logger.debug(util.lazy_format("Resolving object for {0}", ref_uri))
+                logger.debug(util.lazy_format("Resolving object for {0}", uri))
 
-                with self.resolver.resolving(ref_uri) as resolved:
+                with self.resolver.resolving(uri) as resolved:
                     self.resolved[uri] = None # Set incase there is a circular reference in schema definition
                     self.resolved[uri] = self.construct(
                         uri,

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -41,6 +41,34 @@ def test_regression_9():
     builder.build_classes()
 
 
+def test_build_classes_is_idempotent():
+    schema = {
+        "$schema": "http://json-schema.org/schema#",
+        "title": "test",
+        "type": "object",
+        "properties": {
+            "name": {"$ref": "#/definitions/foo"},
+            "email": {"oneOf": [{"type": "string"}, {"type": "integer"}]},
+        },
+        "required": ["email"],
+        "definitions": {
+            "reffed": {
+                "type": "string"
+                },
+            "foo": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/reffed"
+                }
+            }
+        }
+    }
+    builder = pjs.ObjectBuilder(schema)
+    builder.build_classes()
+    builder.build_classes()
+
+
+
 def test_underscore_properties():
     schema = {
         "$schema": "http://json-schema.org/schema#",


### PR DESCRIPTION
The classbuilder works on the schema object, and ends up changing values
in it as types are discovered and resolved. This causes problems when
calling build_classes more than once. This change makes it so the
builder always uses a copy of the schema when calling build_classes()