### PR TITLE
Fix property setting bug when typ is dict

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -737,7 +737,7 @@ def make_property(prop, info, desc=""):
                 continue
               typ = next(t
                          for n, t in validators.SCHEMA_TYPE_MAPPING
-                         if typ['type'] == t)
+                         if typ['type'] == n)
               if typ is None:
                   typ = type(None)
               if isinstance(typ, (list, tuple)):

--- a/test/test_regression_89.py
+++ b/test/test_regression_89.py
@@ -1,0 +1,27 @@
+import pytest
+
+import python_jsonschema_objects as pjs
+
+
+def test_one_of_types():
+    schema = {
+        "$schema": "http://json-schema.org/draft-04/schema",
+        "title": "Example1",
+        "type": "object",
+        "properties": {
+            "foo": {
+                "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "type": "null"
+                    }
+                ]
+            }
+        }
+    }
+
+    ns1 = pjs.ObjectBuilder(schema).build_classes()
+    ns1.Example1(foo='bar')
+    ns1.Example1(foo=None)


### PR DESCRIPTION
Fixed a bug where a StopIteration exception would be raised because of
improper filtering on the `validators.SCHEMA_TYPE_MAPPING` when
searching for a property's type definition.

Added a regression test for the bug. The test uses a schema where a property's `type` was defined in a `oneOf`.
This hits the code path of the bug.