### PR TITLE
Fix where the whole array was passed instead of the element

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -667,7 +667,7 @@ class ClassBuilder(object):
                     typs = []
                     for i, elem in enumerate(detail['items']):
                         uri = "{0}/{1}/<anonymous_{2}>".format(nm, prop, i)
-                        typ = self.construct(uri, detail['items'])
+                        typ = self.construct(uri, elem)
                         typs.append(typ)
 
                     props[prop] = make_property(prop,

--- a/test/test_regression_114.py
+++ b/test/test_regression_114.py
@@ -1,0 +1,32 @@
+import pytest
+import python_jsonschema_objects as pjo
+
+
+def test_114():
+    schema = {
+        "title": "Example",
+        "type": "object",
+        "properties": {
+            "test_regression_114_anon_array": {
+                "type": "array",
+                "items": [
+                    {
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?:(?:\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])\\.){3}(?:\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])$"
+                            },
+                            {
+                                "type": "string",
+                                "pattern": "^((([0-9A-Fa-f]{1,4}:){1,6}:)|(([0-9A-Fa-f]{1,4}:){7}))([0-9A-Fa-f]{1,4})$"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+
+    builder = pjo.ObjectBuilder(schema)
+    test = builder.build_classes()
+    assert test


### PR DESCRIPTION
Since we are looking for 'items' in the code, which should look like so:

[{u'type': u'string'}, {u'type': u'int'}]

passing the array does not have get method which is called in the construct() since it's not a dictionary, whereas the element of the array will.