### PR TITLE
Make a patch to better support null types.

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -292,9 +292,23 @@ class ProtocolBase(collections.MutableMapping):
         """
 
         propname = lambda x: self.__prop_names__[x]
-        missing = [x for x in self.__required__
-                   if propname(x) not in self._properties or
-                   self._properties[propname(x)] is None]
+        missing = []
+        for x in self.__required__:
+
+            # Allow the null type
+            propinfo = self.propinfo(propname(x))
+            nulltype = False
+            if 'type' in propinfo:
+                nulltype = propinfo['type'] == 'null'
+            elif 'oneOf' in propinfo:
+                for o in propinfo['oneOf']:
+                    if 'type' in o and o['type'] == 'null':
+                        nulltype = True
+                        break
+
+            if (propname(x) not in self._properties and nulltype) or \
+                    (self._properties[propname(x)] is None and not nulltype):
+                missing.append(x)
 
         if len(missing) > 0:
             raise validators.ValidationError(

--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -321,7 +321,7 @@ class ProtocolBase(collections.MutableMapping):
         """
         Returns a list of properties which are required and missing.
 
-        Properties are excluded from this list of they are allowed to be the null type.
+        Properties are excluded from this list if they are allowed to be null.
 
         :return: list of missing properties.
         """
@@ -332,17 +332,17 @@ class ProtocolBase(collections.MutableMapping):
 
             # Allow the null type
             propinfo = self.propinfo(propname(x))
-            null_type_permitted = False
+            null_type = False
             if 'type' in propinfo:
-                null_type_permitted = propinfo['type'] == 'null'
+                null_type = propinfo['type'] == 'null'
             elif 'oneOf' in propinfo:
                 for o in propinfo['oneOf']:
                     if 'type' in o and o['type'] == 'null':
-                        null_type_permitted = True
+                        null_type = True
                         break
 
-            if (propname(x) not in self._properties and null_type_permitted) or \
-                    (self._properties[propname(x)] is None and not null_type_permitted):
+            if (propname(x) not in self._properties and null_type) or \
+                    (self._properties[propname(x)] is None and not null_type):
                 missing.append(x)
 
         return missing

--- a/test/test_regression_90.py
+++ b/test/test_regression_90.py
@@ -1,5 +1,3 @@
-import pytest
-
 import python_jsonschema_objects as pjs
 
 
@@ -21,6 +19,9 @@ def test_null_type():
 
     ns1 = pjs.ObjectBuilder(schema).build_classes(strict=True)
     ns1.Example1(foo=None)
+
+
+def test_null_type_one_of():
 
     schema = {
         "$schema": "http://json-schema.org/draft-04/schema",

--- a/test/test_regression_90.py
+++ b/test/test_regression_90.py
@@ -1,0 +1,48 @@
+import pytest
+
+import python_jsonschema_objects as pjs
+
+
+def test_null_type():
+
+    schema = {
+        "$schema": "http://json-schema.org/draft-04/schema",
+        "title": "Example1",
+        "type": "object",
+        "properties": {
+            "foo": {
+                "type": "null"
+            }
+        },
+        "required": [
+            "foo"
+        ]
+    }
+
+    ns1 = pjs.ObjectBuilder(schema).build_classes(strict=True)
+    ns1.Example1(foo=None)
+
+    schema = {
+        "$schema": "http://json-schema.org/draft-04/schema",
+        "title": "Example1",
+        "type": "object",
+        "properties": {
+            "foo": {
+                "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "type": "null"
+                    }
+                ]
+            }
+        },
+        "required": [
+            "foo"
+        ]
+    }
+
+    ns1 = pjs.ObjectBuilder(schema).build_classes(strict=True)
+    ns1.Example1(foo='bar')
+    ns1.Example1(foo=None)


### PR DESCRIPTION
This commit attempts to permit missing parameters if their type could be
the `null` type.

Currently null types are not supported 100% in
python_jsonschema_objects.

Assuming a schema where the type of a variable `foo` is `null`, and
where strict enforcing was used for schema validation:
* `Object(foo=None)` should be valid as is valid as of this commit
* `Object()` should *NOT* be valid but it is valid as of this commit. There might not be a way to get around this.