### PR TITLE
fix issue-27: properties that have defaults are initiatized with defaults

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -199,8 +199,9 @@ class ProtocolBase(collections.MutableMapping):
         # but only for the ones that have defaults set.
         for name in self.__has_default__:
             if name not in props:
-                logger.debug(util.lazy_format("Initializing '{0}' ", name))
-                setattr(self, name, None)
+                default_value = self.__propinfo__[name]['default']
+                logger.debug(util.lazy_format("Initializing '{0}' to '{1}'", name, default_value))
+                setattr(self, name, default_value)
 
         for prop in props:
             try:

--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -200,7 +200,8 @@ class ProtocolBase(collections.MutableMapping):
         for name in self.__has_default__:
             if name not in props:
                 default_value = self.__propinfo__[name]['default']
-                logger.debug(util.lazy_format("Initializing '{0}' to '{1}'", name, default_value))
+                logger.debug(util.lazy_format("Initializing '{0}' to '{1}'",
+                                              name, default_value))
                 setattr(self, name, default_value)
 
         for prop in props:


### PR DESCRIPTION
This PR provides a fix for initializing properties that have defined default values.  An existing issue arises when None is used; and the default values are of an "enum" types that requires the default value.