### PR TITLE
possible name conflicts between classes and properties in build_classes

### DIFF
--- a/python_jsonschema_objects/__init__.py
+++ b/python_jsonschema_objects/__init__.py
@@ -105,7 +105,7 @@ class ObjectBuilder(object):
         kw = {"strict": strict}
         builder = classbuilder.ClassBuilder(self.resolver)
         for nm, defn in iteritems(self.schema.get('definitions', {})):
-            uri = util.resolve_ref_uri(
+            uri = pjo_util.resolve_ref_uri(
                 self.resolver.resolution_scope,
                 "#/definitions/" + nm)
             builder.construct(uri, defn, **kw)

--- a/python_jsonschema_objects/__init__.py
+++ b/python_jsonschema_objects/__init__.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 import python_jsonschema_objects.classbuilder as classbuilder
 import python_jsonschema_objects.literals as literals
 from python_jsonschema_objects.validators import ValidationError
-import python_jsonschema_objects.util
+import python_jsonschema_objects.util as pjo_util
 import python_jsonschema_objects.markdown_support
 
 __all__ = ['ObjectBuilder', 'markdown_support', 'ValidationError']
@@ -116,14 +116,12 @@ class ObjectBuilder(object):
         builder.construct(nm, self.schema,**kw)
         self._resolved = builder.resolved
 
-        return (
-            util.Namespace.from_mapping(dict(
-                (inflection.camelize(uri.split('/')[-1]),
-                 klass) for uri,
-                klass in six.iteritems(builder.resolved)
-                if not util.safe_issubclass(klass, literals.LiteralValue)
-                ))
-        )
+        return (util.Namespace.from_mapping(
+            dict(
+                (inflection.camelize(uri.split('/')[-1]), klass)
+                for uri, klass in six.iteritems(builder.resolved)
+                if not pjo_util.safe_issubclass(klass, literals.LiteralValue)))
+                )
 
 
 if __name__ == '__main__':

--- a/python_jsonschema_objects/__init__.py
+++ b/python_jsonschema_objects/__init__.py
@@ -14,9 +14,9 @@ logger = logging.getLogger(__name__)
 
 import python_jsonschema_objects.classbuilder as classbuilder
 import python_jsonschema_objects.literals as literals
-from python_jsonschema_objects.validators import ValidationError
 import python_jsonschema_objects.util as pjo_util
 import python_jsonschema_objects.markdown_support
+from python_jsonschema_objects.validators import ValidationError
 
 __all__ = ['ObjectBuilder', 'markdown_support', 'ValidationError']
 
@@ -116,7 +116,7 @@ class ObjectBuilder(object):
         builder.construct(nm, self.schema,**kw)
         self._resolved = builder.resolved
 
-        return (util.Namespace.from_mapping(
+        return (pjo_util.Namespace.from_mapping(
             dict(
                 (inflection.camelize(uri.split('/')[-1]), klass)
                 for uri, klass in six.iteritems(builder.resolved)

--- a/python_jsonschema_objects/__init__.py
+++ b/python_jsonschema_objects/__init__.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 import python_jsonschema_objects.classbuilder as classbuilder
+import python_jsonschema_objects.literals as literals
 from python_jsonschema_objects.validators import ValidationError
 import python_jsonschema_objects.util
 import python_jsonschema_objects.markdown_support
@@ -119,7 +120,9 @@ class ObjectBuilder(object):
             util.Namespace.from_mapping(dict(
                 (inflection.camelize(uri.split('/')[-1]),
                  klass) for uri,
-                klass in six.iteritems(builder.resolved)))
+                klass in six.iteritems(builder.resolved)
+                if not util.safe_issubclass(klass, literals.LiteralValue)
+                ))
         )
 
 

--- a/test/test_name_conflict_literal_class.py
+++ b/test/test_name_conflict_literal_class.py
@@ -4,24 +4,25 @@ import python_jsonschema_objects as pjo
 import python_jsonschema_objects.util as util
 from python_jsonschema_objects.classbuilder import ProtocolBase
 
+
 def test_name_conflict_literal_class():
     schema = {
         'title': 'name conflict',
         'type': 'object',
         'definitions': {
-          "Path": {
-            "title": "Path", 
-            "type": "object", 
-            "additionalProperties": False, 
-            "properties": {
-              "path": {
-                "type": "string", 
-              },
-              "parent": {
-                  "$ref": "#/definitions/Path"
-              }
+            "Path": {
+                "title": "Path",
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "path": {
+                        "type": "string",
+                    },
+                    "parent": {
+                        "$ref": "#/definitions/Path"
+                    }
+                }
             }
-          }
         }
     }
     builder = pjo.ObjectBuilder(schema)
@@ -29,5 +30,6 @@ def test_name_conflict_literal_class():
     p = klasses.Path
     # without correction, returned class is #/definitions/Path/path which is a literal
     assert util.safe_issubclass(p, ProtocolBase)
+
 
 test_name_conflict_literal_class()

--- a/test/test_name_conflict_literal_class.py
+++ b/test/test_name_conflict_literal_class.py
@@ -1,0 +1,33 @@
+import pytest
+
+import python_jsonschema_objects as pjo
+import python_jsonschema_objects.util as util
+from python_jsonschema_objects.classbuilder import ProtocolBase
+
+def test_name_conflict_literal_class():
+    schema = {
+        'title': 'name conflict',
+        'type': 'object',
+        'definitions': {
+          "Path": {
+            "title": "Path", 
+            "type": "object", 
+            "additionalProperties": False, 
+            "properties": {
+              "path": {
+                "type": "string", 
+              },
+              "parent": {
+                  "$ref": "#/definitions/Path"
+              }
+            }
+          }
+        }
+    }
+    builder = pjo.ObjectBuilder(schema)
+    klasses = builder.build_classes()
+    p = klasses.Path
+    # without correction, returned class is #/definitions/Path/path which is a literal
+    assert util.safe_issubclass(p, ProtocolBase)
+
+test_name_conflict_literal_class()

--- a/test/test_name_conflict_literal_class.py
+++ b/test/test_name_conflict_literal_class.py
@@ -28,7 +28,8 @@ def test_name_conflict_literal_class():
     builder = pjo.ObjectBuilder(schema)
     klasses = builder.build_classes()
     p = klasses.Path
-    # without correction, returned class is #/definitions/Path/path which is a literal
+    # without correction, returned class is 
+    # #/definitions/Path/path which is a literal
     assert util.safe_issubclass(p, ProtocolBase)
 
 


### PR DESCRIPTION
If a class and a property have the same name, it can happen that build_classes returns the property instead of the expected class

The proposed correction only returns classes which are not subclasses of LiteralValue but not sure it s enough... (what if a property with same name is an object...)
