### PR TITLE
allow user to specify another Resolver or Validator in ObjectBuilder

### DIFF
--- a/python_jsonschema_objects/__init__.py
+++ b/python_jsonschema_objects/__init__.py
@@ -23,7 +23,7 @@ FILE = __file__
 
 class ObjectBuilder(object):
 
-    def __init__(self, schema_uri, resolved={}):
+    def __init__(self, schema_uri, resolved={},resolver=None,validatorClass=None):
         self.mem_resolved = resolved
 
         if isinstance(schema_uri, six.string_types):
@@ -36,17 +36,16 @@ class ObjectBuilder(object):
             uri = os.path.normpath(FILE)
             self.basedir = os.path.dirname(uri)
 
-        self.resolver = jsonschema.RefResolver.from_schema(
-            self.schema,
-            handlers={
+        self.resolver = resolver or jsonschema.RefResolver.from_schema(self.schema)
+        self.resolver.handlers.update({
                 'file': self.relative_file_resolver,
                 'memory': self.memory_resolver
-            }
-        )
+            })
 
-        meta_validator = Draft4Validator(Draft4Validator.META_SCHEMA)
+        validatorClass = validatorClass or Draft4Validator
+        meta_validator = validatorClass(Draft4Validator.META_SCHEMA)
         meta_validator.validate(self.schema)
-        self.validator = Draft4Validator(self.schema,
+        self.validator = validatorClass(self.schema,
                                          resolver=self.resolver)
 
 

--- a/test/test_nondefault_resolver_validator.py
+++ b/test/test_nondefault_resolver_validator.py
@@ -1,0 +1,23 @@
+import pytest  # noqa
+from jsonschema import RefResolver, Draft3Validator
+from jsonschema._utils import load_schema, URIDict
+import python_jsonschema_objects as pjo
+
+
+def test_non_default_resolver_validator(markdown_examples):
+
+    ms = URIDict()
+    draft3 = load_schema('draft3')
+    draft4 = load_schema('draft4')
+    ms[draft3['id']] = draft3
+    ms[draft4['id']] = draft4
+    resolver_with_store = RefResolver(draft3['id'],draft3,ms)
+
+    # 'Other' schema should be valid with draft3
+    builder = pjo.ObjectBuilder(markdown_examples['Other'], 
+                                resolver=resolver_with_store,
+                                validatorClass=Draft3Validator,
+                                resolved=markdown_examples)
+    klasses = builder.build_classes()
+    a = klasses.Other(MyAddress="where I leave")
+    assert a.MyAddress == "where I leave"


### PR DESCRIPTION
#129 

Change init of ObjectBuilder to allow user to use another resolver (for example with a non empty metaschema store) and a different Validator from python-jsonschema (at his own risk). Will make life easier for people working on different versions of the spec. 

add a test case using memory handler



