### PR TITLE
correct bug in propmerge when processing parent objects which have al…

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -559,7 +559,8 @@ class ClassBuilder(object):
 
         properties = {}
         for p in parents:
-            properties = util.propmerge(properties, p.__propinfo__)
+            properties = pjo_util.propmerge(properties,
+                                            getattr(p, '__propinfo__', {}))
 
         if 'properties' in clsdata:
             properties = util.propmerge(properties, clsdata['properties'])

--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -559,7 +559,7 @@ class ClassBuilder(object):
 
         properties = {}
         for p in parents:
-            properties = pjo_util.propmerge(properties,
+            properties = util.propmerge(properties,
                                             getattr(p, '__propinfo__', {}))
 
         if 'properties' in clsdata:

--- a/python_jsonschema_objects/util.py
+++ b/python_jsonschema_objects/util.py
@@ -68,8 +68,9 @@ class ProtocolJSONEncoder(json.JSONEncoder):
 def propmerge(into, data_from):
     """ Merge JSON schema requirements into a dictionary """
     newprops = copy.deepcopy(into)
+    data_from_copy = copy.deepcopy(data_from)
 
-    for prop, propval in six.iteritems(data_from):
+    for prop, propval in six.iteritems(data_from_copy):
         if prop not in newprops:
             newprops[prop] = propval
             continue

--- a/python_jsonschema_objects/util.py
+++ b/python_jsonschema_objects/util.py
@@ -84,7 +84,7 @@ def propmerge(into, data_from):
 
             elif subprop == 'type':
                 def is_object(val):
-                    return (val == 'object') or hasattr(val,'__propinfo__')
+                    return (val == 'object') or hasattr(val, '__propinfo__')
                 if spval != new_sp[subprop]:
                     if (is_object(spval) and is_object(new_sp[subprop])):
                         # not sure what other tests should be done there

--- a/python_jsonschema_objects/util.py
+++ b/python_jsonschema_objects/util.py
@@ -83,8 +83,14 @@ def propmerge(into, data_from):
                 new_sp[subprop] = set(spval) & set(new_sp[subprop])
 
             elif subprop == 'type':
+                def is_object(val):
+                    return (val == 'object') or hasattr(val,'__propinfo__')
                 if spval != new_sp[subprop]:
-                    raise TypeError("Type cannot conflict in allOf'")
+                    if (is_object(spval) and is_object(new_sp[subprop])):
+                        # not sure what other tests should be done there
+                        pass
+                    else:
+                        raise TypeError("Type cannot conflict in allOf'")
 
             elif subprop in ('minLength', 'minimum'):
                 new_sp[subprop] = (new_sp[subprop] if


### PR DESCRIPTION
…ready been processed (ie, info[type]!='object', it has already been replaced by the ProtocolBase class)

Sorry, can't extract simple test case for this right now