### PR TITLE
Fix wrong exception raised in ProtocolBase getitem

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -233,6 +233,7 @@ class ProtocolBase(collections.MutableMapping):
         if name in self.__prop_names__:
             raise KeyError(name)
         if name not in self._extended_properties:
+            #raise KeyError(name)
             raise AttributeError("{0} is not a valid property of {1}".format(
                                  name, self.__class__.__name__))
 

--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -217,7 +217,10 @@ class ProtocolBase(collections.MutableMapping):
       return len(self._extended_properties) + len(self._properties)
 
     def __getitem__(self, key):
-        return getattr(self, key)
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
 
     def __setitem__(self, key, val):
       return setattr(self,key, val)
@@ -232,12 +235,11 @@ class ProtocolBase(collections.MutableMapping):
     def __getattr__(self, name):
         if name in self.__prop_names__:
             raise KeyError(name)
-        if name not in self._extended_properties:
-            #raise KeyError(name)
-            raise AttributeError("{0} is not a valid property of {1}".format(
-                                 name, self.__class__.__name__))
+        if name in self._extended_properties:
+            return self._extended_properties[name]
+        raise AttributeError("{0} is not a valid property of {1}".format(
+                             name, self.__class__.__name__))
 
-        return self._extended_properties[name]
 
     @classmethod
     def propinfo(cls, propname):

--- a/test/test_wrong_exception_protocolbase_getattr.py
+++ b/test/test_wrong_exception_protocolbase_getattr.py
@@ -1,0 +1,42 @@
+import pytest
+
+import python_jsonschema_objects as pjo
+import json
+
+
+@pytest.fixture
+def base_schema():
+    return {
+        'title': 'example',
+        'type': 'object',
+        "additionalProperties": False, 
+        "properties": {
+          "dictLike": {
+            "additionalProperties": {
+              "type": "integer"
+            }, 
+            "type": "object"
+          }
+        }
+    }
+
+
+def test_wrong_exception_protocolbase_getattr(base_schema):
+    """
+    to declare a dict like object in json-schema, we are supposed
+    to declare it as an object of additional properties.
+    When trying to use it as dict, for instance testing if a key is inside
+    the dictionary, methods like __contains__ in the ProtocolBase expect
+    getattr to raise a KeyError. For additional properties, the error raised
+    is AttributeError, breaking the expected behaviour.
+    """
+    builder = pjo.ObjectBuilder(base_schema)
+    ns = builder.build_classes()
+
+    t = ns.Example(dictLike={'a': 0,'b': 1})
+    t.validate()
+    assert 'a' in t.dictLike
+    assert not 'c' in t.dictLike
+
+if __name__ == '__main__':
+    test_wrong_exception_protocolbase_getattr(base_schema()) 

--- a/test/test_wrong_exception_protocolbase_getattr.py
+++ b/test/test_wrong_exception_protocolbase_getattr.py
@@ -27,8 +27,10 @@ def test_wrong_exception_protocolbase_getattr(base_schema):
     to declare it as an object of additional properties.
     When trying to use it as dict, for instance testing if a key is inside
     the dictionary, methods like __contains__ in the ProtocolBase expect
-    getattr to raise a KeyError. For additional properties, the error raised
-    is AttributeError, breaking the expected behaviour.
+    __getitem__ to raise a KeyError. getitem calls __getattr__ without any 
+    exception handling, which raises an AttributeError (necessary for proper
+    behaviour of getattr, for instance).
+    Solution found is to handle AttributeError in getitem and to raise KeyError
     """
     builder = pjo.ObjectBuilder(base_schema)
     ns = builder.build_classes()
@@ -37,6 +39,7 @@ def test_wrong_exception_protocolbase_getattr(base_schema):
     t.validate()
     assert 'a' in t.dictLike
     assert not 'c' in t.dictLike
+    assert getattr(t,'not_present',None) == None
 
 if __name__ == '__main__':
     test_wrong_exception_protocolbase_getattr(base_schema()) 

--- a/test/test_wrong_exception_protocolbase_getitem.py
+++ b/test/test_wrong_exception_protocolbase_getitem.py
@@ -13,7 +13,7 @@ def base_schema():
           "dictLike": {
             "additionalProperties": {
               "type": "integer"
-            }, 
+            },
             "type": "object"
           }
         }
@@ -37,7 +37,7 @@ def test_wrong_exception_protocolbase_getitem(base_schema):
     t = ns.Example(dictLike={'a': 0, 'b': 1})
     t.validate()
     assert 'a' in t.dictLike
-    assert not 'c' in t.dictLike
+    assert 'c' not in t.dictLike
     assert getattr(t, 'not_present', None) is None
 
 

--- a/test/test_wrong_exception_protocolbase_getitem.py
+++ b/test/test_wrong_exception_protocolbase_getitem.py
@@ -21,7 +21,7 @@ def base_schema():
     }
 
 
-def test_wrong_exception_protocolbase_getattr(base_schema):
+def test_wrong_exception_protocolbase_getitem(base_schema):
     """
     to declare a dict like object in json-schema, we are supposed
     to declare it as an object of additional properties.
@@ -42,4 +42,4 @@ def test_wrong_exception_protocolbase_getattr(base_schema):
     assert getattr(t,'not_present',None) == None
 
 if __name__ == '__main__':
-    test_wrong_exception_protocolbase_getattr(base_schema()) 
+    test_wrong_exception_protocolbase_getitem(base_schema()) 

--- a/test/test_wrong_exception_protocolbase_getitem.py
+++ b/test/test_wrong_exception_protocolbase_getitem.py
@@ -1,7 +1,6 @@
 import pytest
 
 import python_jsonschema_objects as pjo
-import json
 
 
 @pytest.fixture
@@ -9,7 +8,7 @@ def base_schema():
     return {
         'title': 'example',
         'type': 'object',
-        "additionalProperties": False, 
+        "additionalProperties": False,
         "properties": {
           "dictLike": {
             "additionalProperties": {
@@ -27,7 +26,7 @@ def test_wrong_exception_protocolbase_getitem(base_schema):
     to declare it as an object of additional properties.
     When trying to use it as dict, for instance testing if a key is inside
     the dictionary, methods like __contains__ in the ProtocolBase expect
-    __getitem__ to raise a KeyError. getitem calls __getattr__ without any 
+    __getitem__ to raise a KeyError. getitem calls __getattr__ without any
     exception handling, which raises an AttributeError (necessary for proper
     behaviour of getattr, for instance).
     Solution found is to handle AttributeError in getitem and to raise KeyError
@@ -35,11 +34,12 @@ def test_wrong_exception_protocolbase_getitem(base_schema):
     builder = pjo.ObjectBuilder(base_schema)
     ns = builder.build_classes()
 
-    t = ns.Example(dictLike={'a': 0,'b': 1})
+    t = ns.Example(dictLike={'a': 0, 'b': 1})
     t.validate()
     assert 'a' in t.dictLike
     assert not 'c' in t.dictLike
-    assert getattr(t,'not_present',None) == None
+    assert getattr(t, 'not_present', None) is None
+
 
 if __name__ == '__main__':
     test_wrong_exception_protocolbase_getitem(base_schema()) 


### PR DESCRIPTION
To declare a dict like object in json-schema, we are supposed to declare it as an object of additional properties. When trying to use it as dict, for instance testing if a key is inside the dictionary, methods like __contains__ in the ProtocolBase expect __getitem__ to raise a KeyError. 
__getitem__ was calling __getattr__ without any exception handling, which raises an AttributeError (necessary for proper behaviour of getattr, for instance).
Solution found is to handle AttributeError in getitem and to raise KeyError