### PR TITLE
Fix #141 by adding an option to only keep titled elements

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -548,6 +548,7 @@ class ClassBuilder(object):
       cls = type(str(nm), tuple((LiteralValue,)), {
         '__propinfo__': {
             '__literal__': clsdata,
+            '__title__': clsdata.get('title'),
             '__default__': clsdata.get('default')}
         })
 
@@ -714,6 +715,8 @@ class ClassBuilder(object):
         props['__has_default__'] = defaults
         if required and kw.get("strict"):
             props['__strict__'] = True
+
+        props['__title__'] = clsdata.get('title')
         cls = type(str(nm.split('/')[-1]), tuple(parents), props)
         self.under_construction.remove(nm)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,9 @@ style = pep440
 versionfile_source = python_jsonschema_objects/_version.py
 versionfile_build = python_jsonschema_objects/_version.py 
 tag_prefix = 
+
+[pep8]
+max-line-length=99
+
+[pycodestyle]
+max-line-length=99


### PR DESCRIPTION
This adds a couple of options to `build_classes` to work around the issue described in #141, where unexpected fields appeared in the namespace. The main addition is `named_only`, which will restrict the set of objects that appear in the namespace to the top level object, and anything which has a `title` attribute. 

The README has been updated to reflect this and test the behavior. I also slightly re-ordered the README.