### PR TITLE
Removing old pandocfilters requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Markdown~=2.4
 inflection==0.2.0
 jsonschema>=2.4.0
-pandocfilters>=1.2
 six>=1.5.2


### PR DESCRIPTION
I dont see this imported anywhere within the project, and doesnt (appear) to be used in any fashion. If it is, please let me know!

Otherwise, removing this is just a wee bit of tech debt cleanup