### PR TITLE
Upstream our oneOf patches

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -586,7 +586,7 @@ class ClassBuilder(object):
             if 'oneOf' in detail:
                 one_of_list = detail['oneOf']
                 if 'required' in one_of_list[0]:
-                  skip_one_of = True
+                    skip_one_of = True
 
             if detail.get('default', None) is not None:
                 defaults.add(prop)

--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -582,12 +582,11 @@ class ClassBuilder(object):
             properties[prop]['raw_name'] = prop
             name_translation[prop] = prop.replace('@', '')
             prop = name_translation[prop]
-            
             skip_one_of = False
             if 'oneOf' in detail:
                 one_of_list = detail['oneOf']
                 if 'required' in one_of_list[0]:
-                skip_one_of = True
+                  skip_one_of = True
 
             if detail.get('default', None) is not None:
                 defaults.add(prop)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Markdown~=2.4
 inflection==0.2.0
 jsonschema>=2.4.0
-pandocfilters>=1.2
 six>=1.5.2


### PR DESCRIPTION
We've made the following changes to our private version of python-jsonschema-object, and are looking to upstream these to benefit the community 

Patch #1 
Add an if other wrap-around return self.as_dict. Knock on wood, this may give similar behavior to what was added on 87451f2?diff=split, but will defer to the community's larger knowledge of this section of code to advise us.

Patch #2
Fix one bug in jsconschema-object to skip oneOf type setting when oneOf is combined with "required", not "type: object"


This branch also has the same content with #145 for the small pandocfilters 