### PR TITLE
Feature: Don't revalidate arrays on every change by default

### DIFF
--- a/development.txt
+++ b/development.txt
@@ -6,3 +6,4 @@ sphinx
 sphinx-autobuild
 recommonmark
 pytest
+pytest-mock

--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -197,7 +197,7 @@ class ProtocolBase(collections.MutableMapping):
             # run its setter. We get it from the class definition and call
             # it directly. XXX Heinous.
             prop = getattr(self.__class__, self.__prop_names__[name])
-            prop.fset(self, val)
+            prop.__set__(self, val)
         else:
             # This is an additional property of some kind
             try:
@@ -633,7 +633,8 @@ class ClassBuilder(object):
                             'type': 'array',
                             'validator': python_jsonschema_objects.wrapper_types.ArrayWrapper.create(
                                 uri,
-                                item_constraint=typ)}
+                                item_constraint=typ,
+                                strict=kw.get('strict'))}
                     else:
                         uri = "{0}/{1}_{2}".format(nm,
                                                    prop, "<anonymous_field>")
@@ -651,15 +652,23 @@ class ClassBuilder(object):
                                     )
                             else:
                                 typ = self.construct(uri, detail['items'])
+
+                            constraints = copy.copy(detail)
+                            constraints['strict'] = kw.get('strict')
                             propdata = {'type': 'array',
-                                        'validator': python_jsonschema_objects.wrapper_types.ArrayWrapper.create(uri, item_constraint=typ,
-                                                                                                                 addl_constraints=detail)}
+                                        'validator': python_jsonschema_objects.wrapper_types.ArrayWrapper.create(
+                                            uri,
+                                            item_constraint=typ,
+                                            **constraints)}
                         except NotImplementedError:
                             typ = detail['items']
+                            constraints = copy.copy(detail)
+                            constraints['strict'] = kw.get('strict')
                             propdata = {'type': 'array',
-                                        'validator': python_jsonschema_objects.wrapper_types.ArrayWrapper.create(uri,
-                                                                                                                 item_constraint=typ,
-                                                                                                                 addl_constraints=detail)}
+                                        'validator': python_jsonschema_objects.wrapper_types.ArrayWrapper.create(
+                                            uri,
+                                            item_constraint=typ,
+                                            **constraints)}
 
                     props[prop] = make_property(prop,
                                                 propdata,
@@ -724,125 +733,7 @@ class ClassBuilder(object):
 
 
 def make_property(prop, info, desc=""):
+    from . import descriptors
 
-    def getprop(self):
-        try:
-            return self._properties[prop]
-        except KeyError:
-            raise AttributeError("No such attribute")
-
-    def setprop(self, val):
-        if isinstance(info['type'], (list, tuple)):
-            ok = False
-            errors = []
-            type_checks = []
-
-            for typ in info['type']:
-              if not isinstance(typ, dict):
-                type_checks.append(typ)
-                continue
-              typ = next(t
-                         for n, t in validators.SCHEMA_TYPE_MAPPING
-                         if typ['type'] == n)
-              if typ is None:
-                  typ = type(None)
-              if isinstance(typ, (list, tuple)):
-                  type_checks.extend(typ)
-              else:
-                  type_checks.append(typ)
-
-            for typ in type_checks:
-                if isinstance(val, typ):
-                    ok = True
-                    break
-                elif hasattr(typ, 'isLiteralClass'):
-                    try:
-                        validator = typ(val)
-                    except Exception as e:
-                        errors.append(
-                            "Failed to coerce to '{0}': {1}".format(typ, e))
-                        pass
-                    else:
-                        validator.validate()
-                        ok = True
-                        break
-                elif util.safe_issubclass(typ, ProtocolBase):
-                    # force conversion- thus the val rather than validator assignment
-                    try:
-                        val = typ(**util.coerce_for_expansion(val))
-                    except Exception as e:
-                        errors.append(
-                            "Failed to coerce to '{0}': {1}".format(typ, e))
-                        pass
-                    else:
-                        val.validate()
-                        ok = True
-                        break
-                elif util.safe_issubclass(typ, python_jsonschema_objects.wrapper_types.ArrayWrapper):
-                    try:
-                        val = typ(val)
-                    except Exception as e:
-                        errors.append(
-                            "Failed to coerce to '{0}': {1}".format(typ, e))
-                        pass
-                    else:
-                        val.validate()
-                        ok = True
-                        break
-
-            if not ok:
-                errstr = "\n".join(errors)
-                raise validators.ValidationError(
-                    "Object must be one of {0}: \n{1}".format(info['type'], errstr))
-
-        elif info['type'] == 'array':
-            val = info['validator'](val)
-            val.validate()
-
-        elif util.safe_issubclass(info['type'],
-                                  python_jsonschema_objects.wrapper_types.ArrayWrapper):
-            # An array type may have already been converted into an ArrayValidator
-            val = info['type'](val)
-            val.validate()
-
-        elif getattr(info['type'], 'isLiteralClass', False) is True:
-            if not isinstance(val, info['type']):
-                validator = info['type'](val)
-                validator.validate()
-                if validator._value is not None:
-                    # This allows setting of default Literal values
-                    val = validator
-
-        elif util.safe_issubclass(info['type'], ProtocolBase):
-            if not isinstance(val, info['type']):
-                val = info['type'](**util.coerce_for_expansion(val))
-
-            val.validate()
-
-        elif isinstance(info['type'], TypeProxy):
-            val = info['type'](val)
-
-        elif isinstance(info['type'], TypeRef):
-            if not isinstance(val, info['type'].ref_class):
-                val = info['type'](**val)
-
-            val.validate()
-
-        elif info['type'] is None:
-            # This is the null value
-            if val is not None:
-                raise validators.ValidationError(
-                    "None is only valid value for null")
-
-        else:
-            raise TypeError("Unknown object type: '{0}'".format(info['type']))
-
-        self._properties[prop] = val
-
-    def delprop(self):
-        if prop in self.__required__:
-            raise AttributeError("'%s' is required" % prop)
-        else:
-            del self._properties[prop]
-
-    return property(getprop, setprop, delprop, desc)
+    prop = descriptors.AttributeDescriptor(prop, info, desc)
+    return prop

--- a/python_jsonschema_objects/descriptors.py
+++ b/python_jsonschema_objects/descriptors.py
@@ -1,0 +1,135 @@
+from . import validators, util, wrapper_types
+from .classbuilder import ProtocolBase, TypeProxy, TypeRef
+
+
+class AttributeDescriptor(object):
+    """ Provides property access for constructed class properties """
+
+    def __init__(self, prop, info, desc=""):
+        self.prop = prop
+        self.info = info
+        self.desc = desc
+
+    def __doc__(self):
+        return self.desc
+
+    def __get__(self, obj, owner=None):
+        if obj is None and owner is not None:
+            return self
+
+        try:
+            return obj._properties[self.prop]
+        except KeyError:
+            raise AttributeError("No such attribute")
+
+    def __set__(self, obj, val):
+        info = self.info
+        if isinstance(info["type"], (list, tuple)):
+            ok = False
+            errors = []
+            type_checks = []
+
+            for typ in info["type"]:
+                if not isinstance(typ, dict):
+                    type_checks.append(typ)
+                    continue
+                typ = next(
+                    t for n, t in validators.SCHEMA_TYPE_MAPPING if typ["type"] == n
+                )
+                if typ is None:
+                    typ = type(None)
+                if isinstance(typ, (list, tuple)):
+                    type_checks.extend(typ)
+                else:
+                    type_checks.append(typ)
+
+            for typ in type_checks:
+                if isinstance(val, typ):
+                    ok = True
+                    break
+                elif hasattr(typ, "isLiteralClass"):
+                    try:
+                        validator = typ(val)
+                    except Exception as e:
+                        errors.append("Failed to coerce to '{0}': {1}".format(typ, e))
+                        pass
+                    else:
+                        validator.validate()
+                        ok = True
+                        break
+                elif util.safe_issubclass(typ, ProtocolBase):
+                    # force conversion- thus the val rather than validator assignment
+                    try:
+                        val = typ(**util.coerce_for_expansion(val))
+                    except Exception as e:
+                        errors.append("Failed to coerce to '{0}': {1}".format(typ, e))
+                        pass
+                    else:
+                        val.validate()
+                        ok = True
+                        break
+                elif util.safe_issubclass(typ, wrapper_types.ArrayWrapper):
+                    try:
+                        val = typ(val)
+                    except Exception as e:
+                        errors.append("Failed to coerce to '{0}': {1}".format(typ, e))
+                        pass
+                    else:
+                        val.validate()
+                        ok = True
+                        break
+
+            if not ok:
+                errstr = "\n".join(errors)
+                raise validators.ValidationError(
+                    "Object must be one of {0}: \n{1}".format(info["type"], errstr)
+                )
+
+        elif info["type"] == "array":
+            val = info["validator"](val)
+            val.validate()
+
+        elif util.safe_issubclass(info["type"], wrapper_types.ArrayWrapper):
+            # An array type may have already been converted into an ArrayValidator
+            val = info["type"](val)
+            val.validate()
+
+        elif getattr(info["type"], "isLiteralClass", False) is True:
+            if not isinstance(val, info["type"]):
+                validator = info["type"](val)
+                validator.validate()
+                if validator._value is not None:
+                    # This allows setting of default Literal values
+                    val = validator
+
+        elif util.safe_issubclass(info["type"], ProtocolBase):
+            if not isinstance(val, info["type"]):
+                val = info["type"](**util.coerce_for_expansion(val))
+
+            val.validate()
+
+        elif isinstance(info["type"], TypeProxy):
+            val = info["type"](val)
+
+        elif isinstance(info["type"], TypeRef):
+            if not isinstance(val, info["type"].ref_class):
+                val = info["type"](**val)
+
+            val.validate()
+
+        elif info["type"] is None:
+            # This is the null value
+            if val is not None:
+                raise validators.ValidationError("None is only valid value for null")
+
+        else:
+            raise TypeError("Unknown object type: '{0}'".format(info["type"]))
+
+        obj._properties[self.prop] = val
+
+    def __delete__(self, obj):
+        prop = self.prop
+        if prop in obj.__required__:
+            raise AttributeError("'%s' is required" % prop)
+        else:
+            del obj._properties[prop]

--- a/test/test_regression_143.py
+++ b/test/test_regression_143.py
@@ -1,6 +1,7 @@
 import python_jsonschema_objects as pjs
 import python_jsonschema_objects.wrapper_types
 
+
 def test_limited_validation(mocker):
     schema = {
         "title": "Example Schema",
@@ -10,15 +11,72 @@ def test_limited_validation(mocker):
         },
     }
 
-    mockAW = mocker.patch.object(
-        python_jsonschema_objects.wrapper_types, 'ArrayWrapper', 
-        wraps=python_jsonschema_objects.wrapper_types.ArrayWrapper
-        )
-
     ob = pjs.ObjectBuilder(schema)
     ns1 = ob.build_classes()
-    import pdb; pdb.set_trace()
+    validator = ns1.ExampleSchema.a.info["validator"]([])
+    validate_items = mocker.patch.object(
+        validator, "validate_items", side_effect=validator.validate_items
+    )
+    validate = mocker.patch.object(
+        validator, "validate", side_effect=validator.validate
+    )
+    mocker.patch.dict(
+        ns1.ExampleSchema.a.info,
+        {"validator": mocker.MagicMock(return_value=validator)},
+    )
 
     foo = ns1.ExampleSchema()
-    foo.a.append('foo')
-    print(foo.for_json())
+    # We expect validation to be called on creation
+    assert validate_items.call_count == 1
+
+    # We expect manipulation to not revalidate immediately without strict
+    foo.a.append("foo")
+    foo.a.append("bar")
+    assert validate_items.call_count == 1
+
+    # We expect accessing data elements to cause a revalidate, but only the first time
+    print(foo.a[0])
+    assert validate_items.call_count == 2
+
+    print(foo.a)
+    assert foo.a == ["foo", "bar"]
+    assert validate_items.call_count == 2
+
+
+def test_strict_validation(mocker):
+    """ Validate that when specified as strict, validation still occurs on every change"""
+    schema = {
+        "title": "Example Schema",
+        "type": "object",
+        "properties": {
+            "a": {"type": "array", "items": {"type": "string"}, "default": []}
+        },
+    }
+
+    ob = pjs.ObjectBuilder(schema)
+    ns1 = ob.build_classes(strict=True)
+    validator = ns1.ExampleSchema.a.info["validator"]([])
+    validate_items = mocker.patch.object(
+        validator, "validate_items", side_effect=validator.validate_items
+    )
+    validate = mocker.patch.object(
+        validator, "validate", side_effect=validator.validate
+    )
+    mocker.patch.dict(
+        ns1.ExampleSchema.a.info,
+        {"validator": mocker.MagicMock(return_value=validator)},
+    )
+
+    foo = ns1.ExampleSchema()
+    # We expect validation to be called on creation
+    assert validate_items.call_count == 1
+
+    # We expect manipulation to revalidate immediately with strict
+    foo.a.append("foo")
+    foo.a.append("bar")
+    assert validate_items.call_count == 3
+
+    # We expect accessing data elements to not revalidate because strict would have revalidated on load
+    print(foo.a[0])
+    print(foo.a)
+    assert foo.a == ["foo", "bar"]

--- a/test/test_regression_143.py
+++ b/test/test_regression_143.py
@@ -1,0 +1,24 @@
+import python_jsonschema_objects as pjs
+import python_jsonschema_objects.wrapper_types
+
+def test_limited_validation(mocker):
+    schema = {
+        "title": "Example Schema",
+        "type": "object",
+        "properties": {
+            "a": {"type": "array", "items": {"type": "string"}, "default": []}
+        },
+    }
+
+    mockAW = mocker.patch.object(
+        python_jsonschema_objects.wrapper_types, 'ArrayWrapper', 
+        wraps=python_jsonschema_objects.wrapper_types.ArrayWrapper
+        )
+
+    ob = pjs.ObjectBuilder(schema)
+    ns1 = ob.build_classes()
+    import pdb; pdb.set_trace()
+
+    foo = ns1.ExampleSchema()
+    foo.a.append('foo')
+    print(foo.for_json())

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,5 @@ deps =
   .
   coverage
   pytest
+  pytest-mock
 


### PR DESCRIPTION
Fixes #143 by checking dirty flags for arrays and properties before revalidating. In order to allow for strict mode, this also passes the 'strict' flag down to the Array validator, in which case it will revalidate on every change.