### PR TITLE
Test in python3.7 as well

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,8 @@ if __name__ == '__main__':
               'Programming Language :: Python :: 2.7',
               'Programming Language :: Python :: 3',
               'Programming Language :: Python :: 3.5',
+              'Programming Language :: Python :: 3.6',
+              'Programming Language :: Python :: 3.7',
               'Intended Audience :: Developers',
               'Development Status :: 4 - Beta',
               'License :: OSI Approved :: MIT License',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 
 [tox]
-envlist = py27, py35, py36
+envlist = py27, py35, py36, py37
 
 [testenv]
 ;install_command = pip install {opts} {packages}


### PR DESCRIPTION
Tests pass in py35, py36, and py37 without any issue.
I also updated the `classifiers` to reflect py36 and py37 support.