### PR TITLE
Test against jsonschema versions 2.3, 2.4, 2.5, 2.6, 3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-Markdown~=2.4
-inflection==0.2.0
-jsonschema>=2.4.0
-six>=1.5.2

--- a/setup.py
+++ b/setup.py
@@ -9,44 +9,8 @@ import re
 import sys
 from setuptools import setup, find_packages
 
-
 import versioneer
 
-
-def parse_requirements(path):
-    """Rudimentary parser for the `requirements.txt` file
-
-    We just want to separate regular packages from links to pass them to the
-    `install_requires` and `dependency_links` params of the `setup()`
-    function properly.
-    """
-    try:
-        print(os.path.join(os.path.dirname(__file__), *path.splitlines()))
-        requirements = map(str.strip, local_file(path).splitlines())
-    except IOError:
-        raise RuntimeError("Couldn't find the `requirements.txt' file :(")
-
-    links = []
-    pkgs = []
-    for req in requirements:
-        if not req:
-            continue
-        if 'http:' in req or 'https:' in req:
-            links.append(req)
-            name, version = re.findall("\#egg=([^\-]+)-(.+$)", req)[0]
-            pkgs.append('{0}=={1}'.format(name, version))
-        else:
-            pkgs.append(req)
-
-    return pkgs, links
-
-
-local_file = lambda *f: \
-    open(os.path.join(os.path.dirname(__file__), *f)).read()
-
-
-install_requires, dependency_links = \
-    parse_requirements('requirements.txt')
 
 if __name__ == '__main__':
     if 'register' in sys.argv or 'upload' in sys.argv:
@@ -78,10 +42,9 @@ if __name__ == '__main__':
           install_requires=[
               "inflection~=0.2",
               "Markdown~=2.4",
-              "jsonschema~=2.3",
+              "jsonschema>=2.3",
               "six>=1.5.2"
           ],
-          dependency_links=dependency_links,
           cmdclass=versioneer.get_cmdclass(),
           classifiers=[
               'Programming Language :: Python :: 2',

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,17 @@
 
 [tox]
-envlist = py27, py35, py36, py37
+envlist = py{27,35,36,37}-jsonschema{23,24,25,26,30}
 
 [testenv]
 ;install_command = pip install {opts} {packages}
 commands = coverage run {envbindir}/py.test --doctest-glob='python_jsonschema_objects/*.md'  {posargs} 
            coverage xml --omit=*test* --include=*python_jsonschema_objects*
 deps =
-  .
   coverage
   pytest
   pytest-mock
-
+  jsonschema23: jsonschema~=2.3.0
+  jsonschema24: jsonschema~=2.4.0
+  jsonschema25: jsonschema~=2.5.0
+  jsonschema26: jsonschema~=2.6.0
+  jsonschema30: jsonschema~=3.0.0


### PR DESCRIPTION
I was interested in fixing #154, so I started looking into whether we'd need to make major changes to this library to support `jsonschema` 3.0. But it looks like it works just fine!

I modified the `setup.py` pin on `jsonschema` from `~=2.3` to `>=2.3`, and then updated the `tox.ini` to test against all the current minor versions of `jsonschema>=2.3`. 

Since the combination of `setup.py` and tox handle all the version pinning, `requirements.txt` is no longer necessary, so I deleted that and removed the code in `setup.py` that parsed it.