### PR TITLE
Loosen `inflection` and `Markdown` pins, and support `Markdown` 3.*

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,10 +9,11 @@ import python_jsonschema_objects.markdown_support
 
 @pytest.fixture
 def markdown_examples():
-        md = pkg_resources.resource_filename('python_jsonschema_objects.examples', 'README.md')
-        examples = python_jsonschema_objects.markdown_support.extract_code_blocks(md)
-        examples = {json.loads(v)['title']: json.loads(v) for v in examples['schema']}
-        return examples
+    md = pkg_resources.resource_filename('python_jsonschema_objects.examples', 'README.md')
+    examples = python_jsonschema_objects.markdown_support.extract_code_blocks(md)
+    examples = {json.loads(v)['title']: json.loads(v) for v in examples['schema']}
+    return examples
+
 
 @pytest.fixture(autouse=True)
 def inject_examples(doctest_namespace, markdown_examples):

--- a/python_jsonschema_objects/markdown_support.py
+++ b/python_jsonschema_objects/markdown_support.py
@@ -11,21 +11,33 @@ def extract_code_blocks(filename):
 
     M = markdown.Markdown(extensions=[SpecialFencedCodeExtension()])
 
-    for prep in M.preprocessors.values():
+    preprocessors = M.preprocessors
+    tree_processors = M.treeprocessors
+
+    # Markdown 3.* stores the processors in a class that can be iterated directly.
+    # Markdown 2.* stores them in a dict, so we have to pull out the values.
+    if markdown.version_info[0] == 2:
+        # Note: `markdown.version_info` will be deprecated in favor of
+        # `markdown.__version_info__` in later versions of Markdown.
+        preprocessors = preprocessors.values()
+        tree_processors = tree_processors.values()
+
+    for prep in preprocessors:
         doc = prep.run(doc)
 
     root = M.parser.parseDocument(doc).getroot()
 
-    for treeproc in M.treeprocessors.values():
+    for treeproc in tree_processors:
         newRoot = treeproc.run(root)
         if newRoot is not None:
             root = newRoot
 
     return SpecialFencePreprocessor.EXAMPLES
 
+
 class SpecialFencedCodeExtension(Extension):
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md, md_globals=None):
         """ Add FencedBlockPreprocessor to the Markdown instance. """
         md.registerExtension(self)
 

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ if __name__ == '__main__':
           url='http://python-jsonschema-objects.readthedocs.org/',
           setup_requires=["setuptools>=18.0.0"],
           install_requires=[
-              "inflection~=0.2",
-              "Markdown~=2.4",
+              "inflection>=0.2",
+              "Markdown>=2.4",
               "jsonschema>=2.3",
               "six>=1.5.2"
           ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 
 [tox]
-envlist = py{27,35,36,37}-jsonschema{23,24,25,26,30}
+envlist = py{27,35,36,37}-jsonschema{23,24,25,26,30}-markdown{2,3}
 
 [testenv]
 ;install_command = pip install {opts} {packages}
@@ -15,3 +15,5 @@ deps =
   jsonschema25: jsonschema~=2.5.0
   jsonschema26: jsonschema~=2.6.0
   jsonschema30: jsonschema~=3.0.0
+  markdown2: Markdown~= 2.4
+  markdown3: Markdown~= 3.0


### PR DESCRIPTION
This is similar to the loosening of the pin on `jsonschema`, but for `inflection` and `Markdown`. This is mainly so that future version bumps of those dependencies don't cause version conflicts later on down the road.

I figured we don't care as much about the minor versions of `Markdown` so I only tested against 2.* and 3.*.

`inflection` hasn't been updated in 4 years so I didn't have another major version to test against.

I replaced the tabs in `markdown_examples` with spaces to be consistent with the rest of the file.