### PR TITLE
Test against python3.7 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
 - '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - '2.7'
 - '3.5'
 - '3.6'
+- '3.7'
 env:
   global:
     - CC_TEST_REPORTER_ID=dc84306013e5ab029d115d8c2f9b27f23ee83b8d73c2dc35fed00954769fc76b


### PR DESCRIPTION
I forgot to make Travis test against python3.7 in #157 (whoops).

I had to update the distribution to xenial because the default (trusty) doesn't support python3.7.