### PR TITLE
Made uniqueItems explicitly look for TRUE and not any value

### DIFF
--- a/python_jsonschema_objects/wrapper_types.py
+++ b/python_jsonschema_objects/wrapper_types.py
@@ -125,7 +125,7 @@ class ArrayWrapper(collections.MutableSequence):
 
     def validate_uniqueness(self):
 
-        if getattr(self, 'uniqueItems', None) is not None:
+        if getattr(self, 'uniqueItems', False) is True:
             testset = set(self.data)
             if len(testset) != len(self.data):
                 raise ValidationError(


### PR DESCRIPTION
Originally, "uniqueItems" was detected like this:
`if getattr(self, 'uniqueItems', None) is not None:`

However, this means that the attribute must simply be set, regardless of true/false. Therefore, if you set `"uniqueItems" : false` it would still test for uniqueness.