### PR TITLE
Fix #164

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -263,7 +263,7 @@ class ProtocolBase(collections.MutableMapping):
 
     def __getattr__(self, name):
         if name in self.__prop_names__:
-            raise KeyError(name)
+            raise AttributeError(name)
         if name in self._extended_properties:
             return self._extended_properties[name]
         raise AttributeError(

--- a/python_jsonschema_objects/markdown_support.py
+++ b/python_jsonschema_objects/markdown_support.py
@@ -14,9 +14,14 @@ def extract_code_blocks(filename):
     preprocessors = M.preprocessors
     tree_processors = M.treeprocessors
 
+    try:
+        version_info = markdown.__version_info__
+    except AttributeError:
+        version_info = markdown.version_info
+
     # Markdown 3.* stores the processors in a class that can be iterated directly.
     # Markdown 2.* stores them in a dict, so we have to pull out the values.
-    if markdown.version_info[0] == 2:
+    if version_info[0] == 2:
         # Note: `markdown.version_info` will be deprecated in favor of
         # `markdown.__version_info__` in later versions of Markdown.
         preprocessors = preprocessors.values()

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -256,8 +256,19 @@ def test_additional_props_permitted_explicitly(markdown_examples):
 def test_still_raises_when_accessing_undefined_attrs(Person):
 
     person = Person()
+    person.firstName = "James"
+
+    # If the attribute doesn't exist, we expect an AttributeError
     with pytest.raises(AttributeError):
         print(person.randomFoo)
+
+    # If the attribute is literal-esq, isn't set but isn't required, accessing it should be fine
+    assert person.gender == None
+
+    # If the attribute is an object, isn't set, but isn't required accessing it should throw an exception
+    with pytest.raises(AttributeError) as e:
+        print(person.address.street)
+        assert "'NoneType' object has no attribute 'street'" in e
 
 
 def test_permits_deletion_of_additional_properties(Person):

--- a/test/test_regression_156.py
+++ b/test/test_regression_156.py
@@ -3,7 +3,9 @@ import python_jsonschema_objects as pjo
 
 
 def test_regression_156(markdown_examples):
-    builder = pjo.ObjectBuilder(markdown_examples['MultipleObjects'], resolved=markdown_examples)
+    builder = pjo.ObjectBuilder(
+        markdown_examples["MultipleObjects"], resolved=markdown_examples
+    )
     classes = builder.build_classes(named_only=True)
 
     er = classes.ErrorResponse(message="Danger!", status=99)

--- a/test/test_wrong_exception_protocolbase_getitem.py
+++ b/test/test_wrong_exception_protocolbase_getitem.py
@@ -35,6 +35,9 @@ def test_wrong_exception_protocolbase_getitem(base_schema):
     assert "c" not in t.dictLike
     assert getattr(t, "not_present", None) is None
 
+    with pytest.raises(AttributeError):
+        assert "a" not in t.notAnAttribute
+
 
 if __name__ == "__main__":
     test_wrong_exception_protocolbase_getitem(base_schema())


### PR DESCRIPTION
Fixes #164 by changing the attribute type. Also adds a bunch of tests, since that had no discernable effect on existing tests. The history of that exception is old and somewhat cryptic, which leads me to believe that the issue that caused it to throw `KeyError` has actually been obviated by something else. 