### PR TITLE
Feature: Fixes #151

### DIFF
--- a/python_jsonschema_objects/pattern_properties.py
+++ b/python_jsonschema_objects/pattern_properties.py
@@ -30,7 +30,7 @@ class ExtensibleValidator(object):
             self._additional_type = True
         else:
             if "$ref" in addlProp:
-                refs = builder.resolve_classes([addlProp])
+                refs = builder.expand_references([addlProp])
             else:
                 uri = "{0}/{1}_{2}".format(
                     name, "<additionalProperties>", "<anonymous>"
@@ -44,7 +44,7 @@ class ExtensibleValidator(object):
 
         for pattern, typedef in six.iteritems(schemadef.get("patternProperties", {})):
             if "$ref" in typedef:
-                refs = builder.resolve_classes([typedef])
+                refs = builder.expand_references([typedef])
             else:
                 uri = "{0}/{1}_{2}".format(name, "<patternProperties>", pattern)
 

--- a/python_jsonschema_objects/pattern_properties.py
+++ b/python_jsonschema_objects/pattern_properties.py
@@ -30,7 +30,7 @@ class ExtensibleValidator(object):
             self._additional_type = True
         else:
             if "$ref" in addlProp:
-                refs = builder.expand_references([addlProp])
+                typ = builder.resolve_type(addlProp["$ref"], name)
             else:
                 uri = "{0}/{1}_{2}".format(
                     name, "<additionalProperties>", "<anonymous>"
@@ -38,23 +38,23 @@ class ExtensibleValidator(object):
                 builder.resolved[uri] = builder.construct(
                     uri, addlProp, (cb.ProtocolBase,)
                 )
-                refs = [builder.resolved[uri]]
+                typ = builder.resolved[uri]
 
-            self._additional_type = refs[0]
+            self._additional_type = typ
 
         for pattern, typedef in six.iteritems(schemadef.get("patternProperties", {})):
             if "$ref" in typedef:
-                refs = builder.expand_references([typedef])
+                typ = builder.resolve_type(typedef["$ref"], name)
             else:
                 uri = "{0}/{1}_{2}".format(name, "<patternProperties>", pattern)
 
                 builder.resolved[uri] = builder.construct(
                     uri, typedef, (cb.ProtocolBase,)
                 )
-                refs = [builder.resolved[uri]]
+                typ = builder.resolved[uri]
 
             self._pattern_types.append(
-                PatternDef(pattern=re.compile(pattern), schema_type=refs[0])
+                PatternDef(pattern=re.compile(pattern), schema_type=typ)
             )
 
     def _make_type(self, typ, val):

--- a/test/test_feature_151.py
+++ b/test/test_feature_151.py
@@ -1,0 +1,31 @@
+import pytest
+import python_jsonschema_objects as pjo
+
+
+def test_simple_array_oneOf():
+    basicSchemaDefn = {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "Test",
+        "properties": {
+            "SimpleArrayOfNumberOrString": {"$ref": "#/definitions/simparray"}
+        },
+        "required": ["SimpleArrayOfNumberOrString"],
+        "type": "object",
+        "definitions": {
+            "simparray": {
+                "oneOf": [
+                    {"type": "array", "items": {"type": "number"}},
+                    {"type": "array", "items": {"type": "string"}},
+                ]
+            }
+        },
+    }
+
+    builder = pjo.ObjectBuilder(basicSchemaDefn)
+
+    ns = builder.build_classes()
+    ns.Test().from_json('{"SimpleArrayOfNumberOrString" : [0, 1]}')
+    ns.Test().from_json('{"SimpleArrayOfNumberOrString" : ["Hi", "There"]}')
+
+    with pytest.raises(pjo.ValidationError):
+        ns.Test().from_json('{"SimpleArrayOfNumberOrString" : ["Hi", 0]}')

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -529,3 +529,12 @@ def test_default_values(default):
 
     x = ns.Test()
     assert x.sample == default["default"]
+
+
+def test_justareference_example(markdown_examples):
+
+    builder = pjs.ObjectBuilder(
+        markdown_examples["Just a Reference"], resolved=markdown_examples
+    )
+    ns = builder.build_classes()
+    ns.JustAReference("Hello")

--- a/test/test_regression_156.py
+++ b/test/test_regression_156.py
@@ -18,3 +18,11 @@ def test_regression_156(markdown_examples):
     # round-trip serialize-deserialize into class defined with `oneOf`
     classes.Multipleobjects.from_json(er.serialize())
     classes.Multipleobjects.from_json(vgr.serialize())
+
+
+def test_toplevel_oneof_gets_a_name(markdown_examples):
+    builder = pjo.ObjectBuilder(
+        markdown_examples["MultipleObjects"], resolved=markdown_examples
+    )
+    classes = builder.build_classes(named_only=True)
+    assert classes.Multipleobjects.__title__ is not None


### PR DESCRIPTION
This resolves an issue where if a oneOf was hidden behind a $ref
at the toplevel of an schema (I know), then it would fail to load properly.

It turns out this is just because the top level reference was using an
old method for resolving  type proxies. Updating it to use the TypeProxy
object resolved the issue.

Some minor refactoring of names too.