### PR TITLE
fix_supported_schema_versions

### DIFF
--- a/python_jsonschema_objects/__init__.py
+++ b/python_jsonschema_objects/__init__.py
@@ -1,32 +1,31 @@
+import codecs
+import copy
+import json
+import logging
+import os.path
+import warnings
+
+import inflection
 import jsonschema
+import six
 from jsonschema import Draft4Validator
 from jsonschema.compat import iteritems
-import re
-import json
-import codecs
-import warnings
-import copy
-import os.path
-import inflection
-import six
-
-import logging
-
-logger = logging.getLogger(__name__)
-
 
 import python_jsonschema_objects.classbuilder as classbuilder
-from python_jsonschema_objects.validators import ValidationError
-import python_jsonschema_objects.util
 import python_jsonschema_objects.markdown_support
+import python_jsonschema_objects.util
+from python_jsonschema_objects.validators import ValidationError
+
+
+logger = logging.getLogger(__name__)
 
 __all__ = ["ObjectBuilder", "markdown_support", "ValidationError"]
 
 FILE = __file__
 
 SUPPORTED_VERSIONS = (
-    "http://json-schema.org/draft-03/schema",
-    "http://json-schema.org/draft-04/schema",
+    "http://json-schema.org/draft-03/schema#",
+    "http://json-schema.org/draft-04/schema#",
 )
 
 

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -15,10 +15,10 @@ logging.basicConfig(level=logging.DEBUG)
     "version, warn",
     [
         ("http://json-schema.org/schema#", True),
-        ("http://json-schema.org/draft-03/schema", False),
-        ("http://json-schema.org/draft-04/schema", False),
-        ("http://json-schema.org/draft-06/schema", True),
-        ("http://json-schema.org/draft-07/schema", True),
+        ("http://json-schema.org/draft-03/schema#", False),
+        ("http://json-schema.org/draft-04/schema#", False),
+        ("http://json-schema.org/draft-06/schema#", True),
+        ("http://json-schema.org/draft-07/schema#", True),
     ],
 )
 def test_warnings_on_schema_version(version, warn):


### PR DESCRIPTION
    Fix supported versions list correspond to https://json-schema.org/understanding-json-schema/reference/schema.html#the-schema-keyword
    This fix removes useless warning.
    Remove unused regex module import.
    Reformat imports in __init__.py file correspond to PEP8.