### PR TITLE
Update README.md - minor documentation fix

### DIFF
--- a/python_jsonschema_objects/examples/README.md
+++ b/python_jsonschema_objects/examples/README.md
@@ -56,7 +56,7 @@ here that the schema above has been loaded in a variable called
 
 ``` python
 >>> import python_jsonschema_objects as pjs
->>> builder = pjs.ObjectBuilder(examples['Example Schema'])
+>>> builder = pjs.ObjectBuilder(examples)
 >>> ns = builder.build_classes()
 >>> Person = ns.ExampleSchema
 >>> james = Person(firstName="James", lastName="Bond")
@@ -122,7 +122,7 @@ them just as you would other literals.
 
 ``` python
 >>> import python_jsonschema_objects as pjs
->>> builder = pjs.ObjectBuilder(examples['Example Schema'])
+>>> builder = pjs.ObjectBuilder(examples)
 >>> ns = builder.build_classes()
 >>> Person = ns.ExampleSchema
 >>> james = Person(firstName="James", lastName="Bond")


### PR DESCRIPTION
The documentation says the JSON-schema for the example should be stored in a variable called `examples` but the code accesses `examples` as a dict containing the schema at ['Example Schema']. This might be a bit confusing for new developers.