### PR TITLE
fixing Python 3.8 ABC deprecation

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -23,7 +23,7 @@ if sys.version_info > (3,):
     long = int
 
 
-class ProtocolBase(collections.MutableMapping):
+class ProtocolBase(collections.abc.MutableMapping):
     """ An instance of a class generated from the provided
     schema. All properties will be validated according to
     the definitions provided. However, whether or not all required

--- a/python_jsonschema_objects/util.py
+++ b/python_jsonschema_objects/util.py
@@ -116,7 +116,7 @@ def resolve_ref_uri(base, ref):
 
 __all__ = ("Namespace", "as_namespace")
 
-from collections import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 
 class _Dummy:

--- a/python_jsonschema_objects/wrapper_types.py
+++ b/python_jsonschema_objects/wrapper_types.py
@@ -10,7 +10,7 @@ from python_jsonschema_objects.util import lazy_format as fmt
 logger = logging.getLogger(__name__)
 
 
-class ArrayWrapper(collections.MutableSequence):
+class ArrayWrapper(collections.abc.MutableSequence):
     """ A wrapper for array-like structures.
 
     This implements all of the array like behavior that one would want,


### PR DESCRIPTION
The current warnings emitted:

DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working