### PR TITLE
Fix #213: Properly support total ordering for literals

### DIFF
--- a/python_jsonschema_objects/literals.py
+++ b/python_jsonschema_objects/literals.py
@@ -22,6 +22,7 @@ def MakeLiteral(name, typ, value, **properties):
     return klass(value)
 
 
+@functools.total_ordering
 class LiteralValue(object):
     """Docstring for LiteralValue """
 
@@ -84,12 +85,16 @@ class LiteralValue(object):
                 validator(paramval, self._value, info)
 
     def __eq__(self, other):
+        if isinstance(other, LiteralValue):
+            return self._value == other._value
         return self._value == other
 
     def __hash__(self):
         return hash(self._value)
 
     def __lt__(self, other):
+        if isinstance(other, LiteralValue):
+            return self._value < other._value
         return self._value < other
 
     def __int__(self):

--- a/test/test_regression_213.py
+++ b/test/test_regression_213.py
@@ -1,0 +1,36 @@
+import json
+import pytest
+import python_jsonschema_objects as pjo
+
+schema = """
+{
+    "title":"whatever",
+    "properties": {
+        "test": {"type": "number"}
+    }
+}
+"""
+
+
+@pytest.fixture
+def schema_json():
+    return json.loads(schema)
+
+
+def test_literals_support_comparisons(schema_json):
+    builder = pjo.ObjectBuilder(schema_json)
+    ns = builder.build_classes()
+
+    thing1 = ns.Whatever()
+    thing2 = ns.Whatever()
+
+    thing1.test = 10
+    thing2.test = 12
+
+    assert thing1.test < thing2.test
+    assert thing1.test == thing1.test
+
+    thing2.test = 10
+
+    assert thing1.test <= thing2.test
+    assert thing1.test == thing2.test


### PR DESCRIPTION

Account for whether or not our comparator is a Literal itself.

Additionally use functools.total_ordering to make sure all
comparisons work.
