### PR TITLE
WIP: Resolve defaults through reffs

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -670,6 +670,9 @@ class ClassBuilder(object):
                 props[prop] = make_property(prop, {"type": typ}, typ.__doc__)
                 properties[prop]["$ref"] = ref
                 properties[prop]["type"] = typ
+                if getattr(typ, "default", None) is not None:
+                    defaults.add(prop)
+                    properties[prop]["default"] = typ.default()
 
             elif "oneOf" in detail:
                 potential = self.expand_references(nm, detail["oneOf"])

--- a/test/test_regression_217.py
+++ b/test/test_regression_217.py
@@ -1,0 +1,37 @@
+import json
+import pytest
+import python_jsonschema_objects as pjo
+
+schema = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "schema.json",
+    "$ref": "#/definitions/test",
+    "definitions": {
+        "test": {
+            "type": "object",
+            "properties": {
+                "name": {"$ref": "#/definitions/name"},
+                "number": {"type": "number", "default": 10},
+                "object": {"$ref": "#/definitions/object"},
+            },
+        },
+        "name": {"type": "string", "default": "String"},
+        "number": {"type": "number", "default": 10},
+        "object": {"type": "object", "default": {}},
+    },
+}
+
+
+@pytest.fixture
+def schema_json():
+    return schema
+
+
+def test_reffed_defaults_work(schema_json):
+    builder = pjo.ObjectBuilder(schema_json)
+    ns = builder.build_classes()
+
+    test = ns.Test()
+
+    expected = {"name": "String", "number": 10, "object": {}}
+    assert test.as_dict() == expected


### PR DESCRIPTION
This partially fixes #217 by appropriately handling defaults when
they're references to literals. However, it's still not working
for objects because the object is prepared to have default
    properties, but not to have a default for the object in
    general.
