### PR TITLE
fix nested oneOf resolution with different schema types (fixes #232)

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,5 @@ repos:
     rev: 20.8b1
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3.9
 

--- a/python_jsonschema_objects/descriptors.py
+++ b/python_jsonschema_objects/descriptors.py
@@ -125,7 +125,11 @@ class AttributeDescriptor(object):
             val.validate()
 
         elif isinstance(info["type"], TypeProxy):
-            val = info["type"](val)
+            val = util.coerce_for_expansion(val)
+            if isinstance(val, dict):
+                val = info["type"](**val)
+            else:
+                val = info["type"](val)
 
         elif isinstance(info["type"], TypeRef):
             if not isinstance(val, info["type"].ref_class):

--- a/python_jsonschema_objects/descriptors.py
+++ b/python_jsonschema_objects/descriptors.py
@@ -80,7 +80,13 @@ class AttributeDescriptor(object):
                         break
                 elif isinstance(typ, TypeProxy):
                     try:
-                        val = typ(**util.coerce_for_expansion(val))
+                        # handle keyword expansion according to expected types
+                        # using keywords like oneOf, value can be an object, array or literal
+                        val = util.coerce_for_expansion(val)
+                        if isinstance(val, dict):
+                            val = typ(**val)
+                        else:
+                            val = typ(val)
                         val.validate()
                     except Exception as e:
                         errors.append("Failed to coerce to '{0}': {1}".format(typ, e))

--- a/python_jsonschema_objects/markdown_support.py
+++ b/python_jsonschema_objects/markdown_support.py
@@ -44,8 +44,11 @@ class SpecialFencedCodeExtension(Extension):
     def extendMarkdown(self, md, md_globals=None):
         """ Add FencedBlockPreprocessor to the Markdown instance. """
         md.registerExtension(self)
-
-        if markdown.version_info[0] >= 3:
+        md_ver = (
+            getattr(markdown, "version_info", None) or
+            getattr(markdown, "__version_info__", None)
+        )
+        if md_ver[0] >= 3:
             md.preprocessors.register(
                 SpecialFencePreprocessor(md), "fenced_code_block", 10
             )

--- a/python_jsonschema_objects/pattern_properties.py
+++ b/python_jsonschema_objects/pattern_properties.py
@@ -71,6 +71,14 @@ class ExtensibleValidator(object):
         ):
             return typ(val)
 
+        if isinstance(typ, cb.TypeProxy):
+            val = util.coerce_for_expansion(val)
+            if isinstance(val, dict):
+                val = typ(**val)
+            else:
+                val = typ(val)
+            return val
+
         raise validators.ValidationError(
             "additionalProperty type {0} was neither a literal "
             "nor a schema wrapper: {1}".format(typ, val)
@@ -96,7 +104,7 @@ class ExtensibleValidator(object):
             valtype = valtype[0]
             return MakeLiteral(name, valtype, val)
 
-        elif isinstance(self._additional_type, type):
+        elif isinstance(self._additional_type, (type, cb.TypeProxy)):
             return self._make_type(self._additional_type, val)
 
         raise validators.ValidationError(

--- a/test/test_nested_arrays.py
+++ b/test/test_nested_arrays.py
@@ -9,12 +9,14 @@ import logging
 @pytest.fixture
 def nested_arrays():
     return {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "title": "example",
         "properties": {
             "foo": {
                 "type": "array",
                 "items": {
                     "type": "array",
+                    # FIXME: not supported anymore in https://json-schema.org/draft/2020-12
                     "items": [{"type": "number"}, {"type": "number"}],
                 },
             }

--- a/test/test_regression_232.py
+++ b/test/test_regression_232.py
@@ -1,0 +1,81 @@
+import jsonschema
+import pytest
+import python_jsonschema_objects as pjo
+
+schema = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "title": "myschema",
+    "type": "object",
+    "definitions": {
+        "MainObject": {
+            "title": "Main Object",
+            "additionalProperties": False,
+            "type": "object",
+            "properties": {
+                "location": {
+                    "title": "location",
+                    "oneOf": [
+                        {"$ref": "#/definitions/UNIQUE_STRING"},
+                        {"$ref": "#/definitions/Location"},
+                    ],
+                }
+            },
+        },
+        "Location": {
+            "title": "Location",
+            "description": "A Location represents a span on a specific sequence.",
+            "oneOf": [
+                {"$ref": "#/definitions/LocationIdentifier"},
+                {"$ref": "#/definitions/LocationTyped"},
+            ],
+        },
+        "LocationIdentifier": {
+            "type": "integer",
+            "minimum": 1,
+        },
+        "LocationTyped": {
+            "additionalProperties": False,
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": ["Location"],
+                    "default": "Location",
+                }
+            },
+        },
+        "UNIQUE_STRING": {
+            "additionalProperties": False,
+            "type": "string",
+            "pattern": "^\\w[^:]*:.+$",
+        },
+    },
+}
+
+
+@pytest.fixture
+def schema_json():
+    return schema
+
+
+def test_nested_oneof_with_different_types(schema_json):
+    builder = pjo.ObjectBuilder(schema_json)
+    ns = builder.build_classes()
+
+    resolver = jsonschema.RefResolver.from_schema(schema_json)
+    main_obj = schema_json["definitions"]["MainObject"]
+
+    test1 = {"location": 12345}
+    test2 = {"location": {"type": "Location"}}
+    test3 = {"location": "unique:12"}
+    jsonschema.validate(test1, main_obj, resolver=resolver)
+    jsonschema.validate(test2, main_obj, resolver=resolver)
+    jsonschema.validate(test3, main_obj, resolver=resolver)
+
+    obj1 = ns.MainObject(**test1)
+    obj2 = ns.MainObject(**test2)
+    obj3 = ns.MainObject(**test3)
+
+    assert obj1.location == 12345
+    assert obj2.location.type == "Location"
+    assert obj3.location == "unique:12"

--- a/test/test_regression_232.py
+++ b/test/test_regression_232.py
@@ -15,6 +15,12 @@ schema = {
                 }
             }
         },
+        "MapObject": {
+            "title": "Map Object",
+            "additionalProperties": {
+                "$ref": "#/definitions/Location"
+            }
+        },
         "MainObject": {
             "title": "Main Object",
             "additionalProperties": False,
@@ -106,3 +112,24 @@ def test_nested_oneof_with_different_types_by_reference(schema_json):
 
     assert obj1.location == 12345
     assert obj2.location.type == "Location"
+
+
+def test_nested_oneof_with_different_types_in_additional_properties(schema_json):
+    builder = pjo.ObjectBuilder(schema_json)
+    ns = builder.build_classes()
+
+    resolver = jsonschema.RefResolver.from_schema(schema_json)
+    map_obj = schema_json["definitions"]["MapObject"]
+
+    x_prop_name = "location-id"
+
+    test1 = {x_prop_name: 12345}
+    test2 = {x_prop_name: {"type": "Location"}}
+    jsonschema.validate(test1, map_obj, resolver=resolver)
+    jsonschema.validate(test2, map_obj, resolver=resolver)
+
+    obj1 = ns.MapObject(**test1)
+    obj2 = ns.MapObject(**test2)
+
+    assert obj1[x_prop_name] == 12345
+    assert obj2[x_prop_name].type == "Location"

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 
 [tox]
-envlist = py{35,36,37,38}-jsonschema{23,24,25,26,30}-markdown{2,3}
+envlist = py{36,37,38}-jsonschema{23,24,25,26,30}-markdown{2,3}
 skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.5: py35
     3.6: py36
     3.7: py37
     3.8: py38


### PR DESCRIPTION
Allows a nested `oneOf` to refer to other schema types than `object` by considering the keyword expansion when needed.

## Fixes
- fixes #232
- fix `markdown` package that uses `__version_info__` in more recent versions instead of `version_info`
  (duplicate functionality as https://github.com/cwacek/python-jsonschema-objects/pull/230)
- fix broken test that assumed default schema `draft-04` not supported by new default in `jsonschema`