### PR TITLE
bugfix: Pin jsonschema below 4.18 (not 4.1.8)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
         install_requires=[
             "inflection>=0.2",
             "Markdown>=2.4",
-            "jsonschema>=2.3,<4.1.8",
+            "jsonschema>=2.3,<4.18",
             "six>=1.5.2",
         ],
         cmdclass=versioneer.get_cmdclass(),


### PR DESCRIPTION
Closes #237

This fixes the upper bound for the jsonschema dependency, so any version below 4.18 is allowed.

As a matter of style, I was unsure if I should specify the upper bound as 4.18 or 4.18.0, but the lower bound is specified in major.minor style, so I went with 4.18.