### PR TITLE
tests: Update tox.ini versions list to match CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,15 @@
 
 [tox]
-envlist = py{36,37,38}-jsonschema{23,24,25,26,30,40}-markdown{2,3}
+envlist = py{37,38,39,310,311}-jsonschema{23,24,25,26,30,40}-markdown{2,3}
 skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
 
 
 [testenv]


### PR DESCRIPTION
Currently, CI runs tests on Python 3.7-3.11, but `tox.ini` still lists the older range 3.6-3.8.

That affects local development, because running `tox` does not test with 3.9, 3.10, or 3.11, even when those Python versions are installed on the local development system. (I noticed this when locally testing #238.) Less importantly, it is probably not necessary to test on Python 3.6 anymore, because it has been unsupported for a long time.

This PR changes the Python version range in `tox.ini` to match the range tested on CI (in the `build` step in `pythonpackage.yml`).

Although Python 3.7 is [recently unsupported](https://devguide.python.org/versions/) as well, I have not removed it in this PR. If 3.7 is to be removed from `tox.ini`, then that should also be done in `pythonpackage.yml`, and it may make sense to update some other things there at the same time. I'd be pleased to make any requested changes to this PR, but my current thinking is that I should keep it narrowly scoped to tox, and open a separate PR later for changes that include modifying `pythonpackage.yml`.

I have tested these changes locally by running `tox` on an Ubuntu 22.04.3 LTS system with Python 3.7.17, 3.8.17, 3.9.17, 3.10.12 and 3.11.4 installed.