### PR TITLE
build: Update classifiers stating Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,6 @@
 # <python_jsonschema_objects - An object wrapper for JSON Schema definitions>
 # Copyright (C) <2014-2016>  Chris Wacek <cwacek@gmail.com
 
-import ast
-import os
-import re
 import sys
 from setuptools import setup, find_packages
 
@@ -49,12 +46,12 @@ if __name__ == "__main__":
         ],
         cmdclass=versioneer.get_cmdclass(),
         classifiers=[
-            "Programming Language :: Python :: 2",
-            "Programming Language :: Python :: 2.7",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.5",
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
             "Intended Audience :: Developers",
             "Development Status :: 4 - Beta",
             "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This updates the classifiers listed in `setup.py`.

Removals:

- **Python 2 classifiers.** Although a significant amount of the code remains written in the common subset of Python 2 and Python 3, the codebase overall no longer supports Python 2. For example, `collections.abc` is imported.
- **Python 3.5.** Not all tests reliably pass. Specifically, `test_regression_208` sometimes passes and sometimes raises `TypeError`. Later versions do not show such nondeterministic behavior, even when the test is run many times in succession (it always passes).
- **Python 3.6.** Tests still pass. This version does appear still to work. However, 3.6 has been unsupported by the PSF for a significant time, and it is no longer tested in `tox.ini` or in the CI test workflow.

Additions: **3.8**, **3.9**, **3.10**, and **3.11**. (Along with 3.7, which was already listed, these are the actual supported versions. These versions are tested regularly on CI, with all tests passing.)

While editing the classifiers, I also removed some unused imports.

I was unsure if I should really remove the 3.6 classifier at this time, but removing it doesn't prevent installation on 3.6, removing it achieves consistency with changes in #240, and from https://github.com/cwacek/python-jsonschema-objects/pull/240#issuecomment-1670453599 it appears that 3.6 support is not a goal.

It may make sense to add 3.12 later once any changes needed to install and pass all tests locally and on CI have been made, but I did not add it here.

I was unsure if the commit here should be prefixed `build:`, `cleanup:`, or something else. I can amend the message and force-push if that would be helpful.