### PR TITLE
cleanup: Update tools listed in development.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
-nosetests.xml
 coverage.xml
 *,cover
 

--- a/development.txt
+++ b/development.txt
@@ -1,9 +1,9 @@
-nose==1.3.0
-rednose==0.4.1
-pyandoc
+black
+coverage
 pandoc
-sphinx
-sphinx-autobuild
-recommonmark
+pyandoc
 pytest
 pytest-mock
+recommonmark
+sphinx
+sphinx-autobuild


### PR DESCRIPTION
This updates the "development requirements" file development.txt to remove some packages that are no longer in use and add some that were not listed but are in use. This file, which is not being used on CI but is helpful in local development, is updated as follows:

- Remove nose and rednose, which are long-unused. nosetests is not currently being used on this project, which was migrated to pytest some time ago, and it also doesn't support Python 3.10+.

- Add coverage, which is used heavily, and already listed as a dependency (and used) in tox.ini.

- Add black, which is used as a linter on CI, to make local linting and fixing easier. Although black is given with an exact version on CI, I have omitted the version number here, since one benefit of having black in development.txt is to test new black versions before updating the version number for CI. (If a new version is installed that produces unwanted formatting, this will still be caught on CI.)

This also sorts the list alphabetically.