### PR TITLE
cleanup: Simplify test commands, harmonize style

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,19 @@
-
 [tox]
 envlist = py{37,38,39,310,311}-jsonschema{23,24,25,26,30,40}-markdown{2,3}
 skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.7: py37
-    3.8: py38
-    3.9: py39
-    3.10: py310
-    3.11: py311
-
+  3.7: py37
+  3.8: py38
+  3.9: py39
+  3.10: py310
+  3.11: py311
 
 [testenv]
-;install_command = pip install {opts} {packages}
-commands = python -m coverage run {envbindir}/py.test --doctest-glob='python_jsonschema_objects/*.md'  {posargs}
-           python -m coverage xml --omit="*test*"
+commands =
+  coverage run {envbindir}/pytest --doctest-glob='python_jsonschema_objects/*.md' {posargs}
+  coverage xml --omit='*test*'
 deps =
   coverage
   pytest
@@ -26,5 +24,5 @@ deps =
   jsonschema26: jsonschema~=2.6.0
   jsonschema30: jsonschema~=3.0.0
   jsonschema40: jsonschema~=4.0
-  markdown2: Markdown~= 2.4
-  markdown3: Markdown~= 3.0
+  markdown2: Markdown~=2.4
+  markdown3: Markdown~=3.0


### PR DESCRIPTION
This simplifies the test command in `tox.ini` by:

- Using `coverage` directly (`python -m` no longer needed on any platforms)
- Using `pytest` instead of the very old `py.test` command

It also improves stylistic consistency in `tox.ini`, mostly in how whitespace is used. I've tried to put everything in the style that appears most preferred based on what is already there.

I had originally made these changes (locally) as part of a larger change that added experimental Python 3.12 support. But I realized that this cleanup is conceptually separate, should probably be reviewed separately, and seems to be of value whether or not the addition of experimental 3.12 testing is added afterwards. So I've opened this PR for just the cleanup.