### PR TITLE
workflows: Update black and improve command

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,19 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip 
-        pip install black==23.3.0
+        python -m pip install --upgrade pip
+        pip install black==23.7.0
     - name: Lint with black
-      run: | 
-        git ls-files | grep '\.py' | grep -v versioneer.py
-        black --check --diff $(git ls-files | grep '\.py' | grep -v versioneer.py)
-    
+      run: |
+        black --check --diff --extend-exclude=versioneer.py .
+
   build:
 
     needs: lint
@@ -51,9 +50,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip 
+        python -m pip install --upgrade pip
         pip install tox tox-gh-actions
     - name: Test with pytest
       run: |
         tox
-  

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
 repos:
-  - repo: https://github.com/ambv/black
-    rev:  23.3.0
+  - repo: https://github.com/psf/black
+    rev:  23.7.0
     hooks:
     - id: black
       language_version: python3.9
-


### PR DESCRIPTION
This updates black and improves the command used to run it.

- Update repo URL from `ambv/black` to `psf/black` in pre-commit hook
- Update black version from 23.3.0 to 23.7.0 in pre-commit hook
- Update black version (same as above) in the linting job
- Make command simpler and more robust, using `--extend-exclude`

The change to the command is probably the most significant of these changes. The main reason the command is now more robust is that it was previously using `$()` command substitution in a way that would do the wrong thing on filenames that contain whitespace or special characters like `*` (though there is also the issue that grep would match `.py` anywhere in filenames rather than just at the end). This repository doesn't contain any files with such names, but even if such filenames are deliberately avoided, they could arise by accident.

There are other files than `versioneer.py` that black should ignore, because it should ignore files in locations ignored by git, but black defaults to this behavior (at least in recent versions), and using `--extend-exclude` (in contrast to `--exclude`) ensures that everything black would exclude if its exclusion were not customized stays excluded. This allows the path to be passed just as `.` and eliminates the need to use `git ls-files`.

I have verified that this scans the same 44 files in the repository as before and continues to regard their style as passing.