### PR TITLE
workflows: Update CI action versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ name: Publish Packages
 # events but only for the master branch
 on:
   release:
-    types: 
+    types:
       - created
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -14,18 +14,17 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8      
+          python-version: 3.8
       - name: build-archives
         run: |
           python -m pip install -U pip wheel
           python setup.py bdist_wheel sdist
       - name: pypi-publish
-        uses: pypa/gh-action-pypi-publish@v1.1.0
+        uses: pypa/gh-action-pypi-publish@v1.8.10
         with:
           user: __token__
           password: ${{ secrets.PYPI_PJO_TOKEN }}
-

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,19 +16,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip 
+        python -m pip install --upgrade pip
         pip install black==23.3.0
     - name: Lint with black
-      run: | 
+      run: |
         git ls-files | grep '\.py' | grep -v versioneer.py
         black --check --diff $(git ls-files | grep '\.py' | grep -v versioneer.py)
-    
+
   build:
 
     needs: lint
@@ -46,14 +46,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip 
+        python -m pip install --upgrade pip
         pip install tox tox-gh-actions
     - name: Test with pytest
       run: |
         tox
-  


### PR DESCRIPTION
This updates versions of GitHub Actions, *except* in the `stale.yml` workflow. The upgraded actions in other workflows are `checkout`, `setup-python`, and `gh-action-pypi-publish`.

The checkout and setup-python actions were upgraded across major versions. Although it is possible for major version updates to introduce incompatibilities, I believe the advantages decisively outweigh the disadvantages, because:

- The syntax the workflows are using remains supported.
- They were upgraded in some places already, just not all.
- As noted in warning annotations shown on this project's [workflow runs](https://github.com/cwacek/python-jsonschema-objects/actions/runs/5803097120), old Node 12 actions [may break around 27 September](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) when GitHub Actions removes Node 12 support and runs all actions on Node 16.
- There may be a benefit to bugfixes in the newer versions.

For `gh-action-pypi-publish`, the minor version upgrade includes security updates to internal dependencies. This happened in [1.8.9](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.8.9).

I have not touched `stale.yml` here, even though the action it uses is specified to use a very old version, because that workflow is currently disabled (which appears to have been done automatically at some point during a lull in activity when no repository activity was detected for 60 days). Modifying it might re-enable it, which might not be desired.