### PR TITLE
cleanup: Remove unused test_regression_143 "validate" mocks

### DIFF
--- a/test/test_regression_143.py
+++ b/test/test_regression_143.py
@@ -17,9 +17,6 @@ def test_limited_validation(mocker):
     validate_items = mocker.patch.object(
         validator, "validate_items", side_effect=validator.validate_items
     )
-    validate = mocker.patch.object(
-        validator, "validate", side_effect=validator.validate
-    )
     mocker.patch.dict(
         ns1.ExampleSchema.a.info,
         {"validator": mocker.MagicMock(return_value=validator)},
@@ -28,23 +25,19 @@ def test_limited_validation(mocker):
     foo = ns1.ExampleSchema()
     # We expect validation to be called on creation
     assert validate_items.call_count == 1
-    assert validate.call_count == 1
 
     # We expect manipulation to not revalidate immediately without strict
     foo.a.append("foo")
     foo.a.append("bar")
     assert validate_items.call_count == 1
-    assert validate.call_count == 1
 
     # We expect accessing data elements to cause a revalidate, but only the first time
     print(foo.a[0])
     assert validate_items.call_count == 2
-    assert validate.call_count == 2
 
     print(foo.a)
     assert foo.a == ["foo", "bar"]
     assert validate_items.call_count == 2
-    assert validate.call_count == 2
 
 
 def test_strict_validation(mocker):
@@ -63,9 +56,6 @@ def test_strict_validation(mocker):
     validate_items = mocker.patch.object(
         validator, "validate_items", side_effect=validator.validate_items
     )
-    validate = mocker.patch.object(
-        validator, "validate", side_effect=validator.validate
-    )
     mocker.patch.dict(
         ns1.ExampleSchema.a.info,
         {"validator": mocker.MagicMock(return_value=validator)},
@@ -74,13 +64,11 @@ def test_strict_validation(mocker):
     foo = ns1.ExampleSchema()
     # We expect validation to be called on creation
     assert validate_items.call_count == 1
-    assert validate.call_count == 1
 
     # We expect manipulation to revalidate immediately with strict
     foo.a.append("foo")
     foo.a.append("bar")
     assert validate_items.call_count == 3
-    assert validate.call_count == 3
 
     # We expect accessing data elements to not revalidate because strict would have revalidated on load
     print(foo.a[0])

--- a/test/test_regression_143.py
+++ b/test/test_regression_143.py
@@ -28,19 +28,23 @@ def test_limited_validation(mocker):
     foo = ns1.ExampleSchema()
     # We expect validation to be called on creation
     assert validate_items.call_count == 1
+    assert validate.call_count == 1
 
     # We expect manipulation to not revalidate immediately without strict
     foo.a.append("foo")
     foo.a.append("bar")
     assert validate_items.call_count == 1
+    assert validate.call_count == 1
 
     # We expect accessing data elements to cause a revalidate, but only the first time
     print(foo.a[0])
     assert validate_items.call_count == 2
+    assert validate.call_count == 2
 
     print(foo.a)
     assert foo.a == ["foo", "bar"]
     assert validate_items.call_count == 2
+    assert validate.call_count == 2
 
 
 def test_strict_validation(mocker):
@@ -70,11 +74,13 @@ def test_strict_validation(mocker):
     foo = ns1.ExampleSchema()
     # We expect validation to be called on creation
     assert validate_items.call_count == 1
+    assert validate.call_count == 1
 
     # We expect manipulation to revalidate immediately with strict
     foo.a.append("foo")
     foo.a.append("bar")
     assert validate_items.call_count == 3
+    assert validate.call_count == 3
 
     # We expect accessing data elements to not revalidate because strict would have revalidated on load
     print(foo.a[0])


### PR DESCRIPTION
In both `test_regression_143` tests, mocks for `validator.validate` were created and bound to `validate` variables, but no assertions were made using them. The `validate` variables were like the `validate_items` variables, but for `validator.validate` instead of `validator.validate_items`, and unused, with no observable effects.

It is possible to add assertions for `validate.call_count`, alongside the existing `validate_items.call_count` assertions. I did this first, asserting the same number of call counts as in the corresponding `validate_items` assertions. If this is what is intended, then that could be kept, and the second commit in this PR dropped or reverted.

However, considering the effect of that change together with the code introduced in #149 (which completed #143) suggests that, unlike in the case of `validator.validate_items`, the current fact that `validator.validate` is called this number of times, and no more, does not appear to be a something these tests intend to claim and verify. I say that because:

- The specific goal of these tests is to check that the change in #149 is and remains effective, and the key goal there is to avoid unnecessarily revalidating *arrays*, so `validate_items` is the specifically relevant function to instrument.
- There are multiple places where a strictness check can prevent `validate_items` from being called. One is in the `typed_elems` property getter, which conditionally calls validate, which calls `validate_items`, and that's what happens in this test. But `validate` calls `validate_items` conditionally as well. A refactoring of the code could potentially cause more `validate` calls to happen in the non-strict case while still not increasing the call count for `validate_items`.

So I added that second commit to remove the `validate` mocks (and their assertions, which I'd added in the first commit). `validate_items` is of course still mocked and its call counts asserted, as before. The tests' behavior is effectively the same as before, so this PR (if not modified further) is effectively a cleanup, even though neither of the commits in it is by itself a cleanup.

I've kept both commits (rather than squashing them into one) so the reasoning is clear in the code, and also because I think that may make it easier to modify this PR if that turns out to be helpful.