### PR TITLE
tools: Enable Dependabot version updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly 


### PR DESCRIPTION
This enables [Dependabot version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) for GitHub Actions. Considerations:

- This would automate pull requests along the lines of #246, but separate PRs for each dependency.
- [Grouped version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) *could* be set up. The feature is [now considered stable](https://github.blog/changelog/2023-08-24-grouped-version-updates-for-dependabot-are-generally-available/). But GitHub Actions don't tend to be updated often enough that I would expect a benefit from this.
- The main goal of enabling Dependabot version updates is not security. If [Dependabot alerts](https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts) and [Dependabot security updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates) are not currently enabled in this repository's "Code security and analysis" settings, then I recommend enabling them (unless some other automatic mechanism is already handling that). But that is independent of this PR.
- If #256 is to be accepted, then I suggest merging that first, to ensure Dependabot doesn't open a PR to update the unused `stale` action. (Nothing has to be merged into this PR's branch, though.) But even if that is not done, I think Dependabot might *still* not do so, because the workflow is disabled and the action is [not listed in the detected dependencies](https://github.com/cwacek/python-jsonschema-objects/network/dependencies). If Dependabot does open such a PR for `stale`, the PR could simply be closed.
- Actions given with major versions, e.g., `@v3`, will get PRs infrequently, since they automatically use the latest minor (and, where applicable, patch) version in that major version.
- Actions given with a specific versions—currently this is only [gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)—will get PRs more often. That action [seems](https://paste.ubuntu.com/p/rCq274KS2s/) to be [updated](https://github.com/pypa/gh-action-pypi-publish/releases) a couple of times a month, on average.
- Version updates will be *at most* weekly, and often less frequent. `weekly` can be changed to `monthly` or `daily`, if preferred. (This does not affect [Dependabot security updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates), which, if enabled, always attempt to open PRs as soon as a security fix is available.)
- This only enables Dependabot version updates for GitHub Actions dependencies, *not* Python dependencies. This project does not pin narrow versions of any Python dependencies, except conditionally in `tox.ini` where updating them would be wrong because the point is to test with the versions listed (and which Dependabot does not support). So it would not make sense to enable Dependabot version updates for Python dependencies.