### PR TITLE
tools: Update pre-commit configuration for black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev:  23.7.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.7.0
     hooks:
     - id: black
-      language_version: python3.9
+      language_version: python3.11


### PR DESCRIPTION
This builds on the changes in #245, taking care of some things I had missed:

- **Change repo from [psf/black](https://github.com/psf/black) to [psf/black-pre-commit-mirror](https://github.com/psf/black-pre-commit-mirror)**, for speed, as [the `black` documentation has been updated to recommend](https://github.com/psf/black/blob/main/docs/integrations/source_version_control.md). I had previously changed it from [ambv/black](https://github.com/ambv/black) to [psf/black](https://github.com/psf/black), since [ambv/black](https://github.com/ambv/black) redirects to [psf/black](https://github.com/psf/black), and because [psf/black](https://github.com/psf/black) is shown in [the stable docs](https://black.readthedocs.io/en/stable/integrations/source_version_control.html). However, [the latest docs](https://black.readthedocs.io/en/latest/integrations/source_version_control.html) have been updated to recommend [psf/black-pre-commit-mirror](https://github.com/psf/black-pre-commit-mirror) except when a commit hash is being used for the `language_version`. (This applies fully to the stable version of `black`.)
- **Change `language_version` from `python3.9` to `python3.11`**, to follow the recommendation that the latest version supported by the project should be specified. This recommend appears in both the [stable](https://black.readthedocs.io/en/stable/integrations/source_version_control.html) and [latest](https://black.readthedocs.io/en/latest/integrations/source_version_control.html) docs, I had just missed it before.

I have tested this locally by obtaining [pre-commit](https://pre-commit.com/) by running `pipx install pre-commit`, then [making a trivial and partially mis-styled unnecessary change on a throwaway branch and running `git commit`](https://paste.ubuntu.com/p/Q2WpTfSDPH/).