### PR TITLE
fix: handle float operation errors when decimal numbers are used as value of multipleOf

### DIFF
--- a/python_jsonschema_objects/validators.py
+++ b/python_jsonschema_objects/validators.py
@@ -1,4 +1,5 @@
 import logging
+import math
 
 import six
 
@@ -41,7 +42,7 @@ registry = ValidatorRegistry()
 @registry.register()
 def multipleOf(param, value, _):
     quot, rem = divmod(value, param)
-    if rem != 0:
+    if not (math.isclose(rem, 0) or math.isclose(rem, param)):
         raise ValidationError("{0} is not a multiple of {1}".format(value, param))
 
 
@@ -108,7 +109,6 @@ else:
             raise ValidationError(
                 "'{0}' is not formatted as a {1}".format(value, param)
             )
-
 
 type_registry = ValidatorRegistry()
 

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -41,7 +41,7 @@ def test_schema_validation():
         "$id": "test",
         "type": "object",
         "properties": {
-            "name": "string",  #  <-- this is invalid
+            "name": "string",  # <-- this is invalid
             "email": {"oneOf": [{"type": "string"}, {"type": "integer"}]},
         },
         "required": ["email"],
@@ -531,3 +531,24 @@ def test_justareference_example(markdown_examples):
     )
     ns = builder.build_classes()
     ns.JustAReference("Hello")
+
+
+def test_number_multiple_of_validation():
+    schema = {
+        "$schema": "http://json-schema.org/schema#",
+        "$id": "test",
+        "type": "object",
+        "title": "Base",
+        "properties": {
+            "sample": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1000000000,
+                "multipleOf": 0.001
+            },
+        }
+    }
+
+    builder = pjs.ObjectBuilder(schema)
+    ns = builder.build_classes()
+    ns.Base(sample=1.001)


### PR DESCRIPTION
When float numbers are involved in a divmod operation the Remainder may be a number close to 0 or to the Divisor and both scenarios mean that the Divisor is a perfect divisor of the dividend.

closes #259 