### PR TITLE
bugfix: Fix #218 by serializing "null" for "null" types

### DIFF
--- a/python_jsonschema_objects/util.py
+++ b/python_jsonschema_objects/util.py
@@ -45,21 +45,15 @@ class ProtocolJSONEncoder(json.JSONEncoder):
         from python_jsonschema_objects import classbuilder
         from python_jsonschema_objects import wrapper_types
 
-        if isinstance(obj, classbuilder.LiteralValue):
-            return obj._value
-        if isinstance(obj, wrapper_types.ArrayWrapper):
+        if isinstance(
+            obj,
+            (
+                wrapper_types.ArrayWrapper,
+                classbuilder.ProtocolBase,
+                classbuilder.LiteralValue,
+            ),
+        ):
             return obj.for_json()
-        if isinstance(obj, classbuilder.ProtocolBase):
-            props = {}
-            for raw, trans in six.iteritems(obj.__prop_names__):
-                props[raw] = getattr(obj, trans)
-                if props[raw] is None:
-                    del props[raw]
-            for raw, data in six.iteritems(obj._extended_properties):
-                props[raw] = data
-                if props[raw] is None:
-                    del props[raw]
-            return props
         else:
             return json.JSONEncoder.default(self, obj)
 

--- a/test/test_regression_218.py
+++ b/test/test_regression_218.py
@@ -1,0 +1,57 @@
+import pytest
+import json
+import python_jsonschema_objects as pjo
+
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+logging.getLogger().setLevel(logging.DEBUG)
+
+schema = """
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "schema.json",
+  "title":"Null Test",
+  "type": "object",
+  "$ref": "#/definitions/test",
+  "definitions": {
+    "test": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "default": "String"
+        },
+        "id": {
+          "type": "null",
+          "default": null
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@pytest.fixture
+def schema_json():
+    return json.loads(schema)
+
+
+@pytest.fixture
+def ns(schema_json):
+    builder = pjo.ObjectBuilder(schema_json)
+    ns = builder.build_classes()
+    return ns
+
+
+def test_defaults_serialize_for_nullable_types(ns):
+    logging.basicConfig(level=logging.DEBUG)
+    logging.getLogger().setLevel(logging.DEBUG)
+    thing1 = ns.NullTest()
+
+    serialized = thing1.as_dict()
+    print(serialized)
+    assert json.dumps(serialized) == """{"name": "String", "id": null}"""
+    serialized = thing1.serialize()
+    assert serialized == """{"name": "String", "id": null}"""


### PR DESCRIPTION
+ There were two sets of similar JSON serialization logic in place. This unifies them by just making all our custom objects call for_json() which already does the right thing.
+ The actual bug is fixed by permitting None values to serialize to JSON, iff the type of the object is "null"

Aside: I still don't understand why objects with _type_ null exist
       in the JSONSchema spec, but w/e.