### PR TITLE
Migrate to jsonschema 4.18

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu, macos, windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - experimental: false
           - python-version: "3.12"

--- a/python_jsonschema_objects/__init__.py
+++ b/python_jsonschema_objects/__init__.py
@@ -10,25 +10,40 @@ import warnings
 import inflection
 import jsonschema
 import six
-from jsonschema import Draft4Validator
-
-from python_jsonschema_objects import classbuilder, markdown_support, util
+import python_jsonschema_objects.classbuilder as classbuilder
+import python_jsonschema_objects.markdown_support
+import python_jsonschema_objects.util
 from python_jsonschema_objects.validators import ValidationError
+from typing import Optional
+
+from jsonschema_specifications import REGISTRY as SPECIFICATIONS
+from referencing import Registry, Resource
+import referencing.typing
+import referencing.jsonschema
+import referencing.retrieval
+
 
 logger = logging.getLogger(__name__)
+
+__all__ = ["ObjectBuilder", "markdown_support", "ValidationError"]
 
 FILE = __file__
 
 SUPPORTED_VERSIONS = (
-    "http://json-schema.org/draft-03/schema#",
-    "http://json-schema.org/draft-04/schema#",
+    "http://json-schema.org/draft-03/schema",
+    "http://json-schema.org/draft-04/schema",
 )
 
 
 class ObjectBuilder(object):
-    def __init__(self, schema_uri, resolved={}, resolver=None, validatorClass=None):
-        self.mem_resolved = resolved
-
+    def __init__(
+        self,
+        schema_uri,
+        resolved={},
+        registry: Optional[referencing.Registry] = None,
+        resolver: Optional[referencing.typing.Retrieve] = None,
+        specification_uri: str = "http://json-schema.org/draft-04/schema",
+    ):
         if isinstance(schema_uri, six.string_types):
             uri = os.path.normpath(schema_uri)
             self.basedir = os.path.dirname(uri)
@@ -41,7 +56,7 @@ class ObjectBuilder(object):
 
         if (
             "$schema" in self.schema
-            and self.schema["$schema"] not in SUPPORTED_VERSIONS
+            and self.schema["$schema"].rstrip("#") not in SUPPORTED_VERSIONS
         ):
             warnings.warn(
                 "Schema version {} not recognized. Some "
@@ -50,15 +65,78 @@ class ObjectBuilder(object):
                 )
             )
 
-        self.resolver = resolver or jsonschema.RefResolver.from_schema(self.schema)
-        self.resolver.handlers.update(
-            {"file": self.relative_file_resolver, "memory": self.memory_resolver}
-        )
+        if registry is not None:
+            if not isinstance(registry, referencing.Registry):
+                raise TypeError("registry must be a Registry instance")
 
-        validatorClass = validatorClass or Draft4Validator
-        meta_validator = validatorClass(validatorClass.META_SCHEMA)
+            if resolver is not None:
+                raise AttributeError(
+                    "Cannot specify both registry and resolver. If you provide your own registry, pass the resolver directly to that"
+                )
+            self.registry = registry
+        else:
+            if resolver is not None:
+
+                def file_and_memory_handler(uri):
+                    if uri.startswith("file:"):
+                        return Resource.from_contents(self.relative_file_resolver(uri))
+                    return resolver(uri)
+
+                self.registry = Registry(retrieve=file_and_memory_handler)
+            else:
+
+                def file_and_memory_handler(uri):
+                    if uri.startswith("file:"):
+                        return Resource.from_contents(self.relative_file_resolver(uri))
+                    raise RuntimeError(
+                        "No remote resource resolver provided. Cannot resolve {}".format(
+                            uri
+                        )
+                    )
+
+                self.registry = Registry(retrieve=file_and_memory_handler)
+
+        if len(resolved) > 0:
+            warnings.warn(
+                "Use of 'memory:' URIs is deprecated. Provide a registry with properly resolved references "
+                "if you want to resolve items externally.",
+                DeprecationWarning,
+            )
+        for uri, contents in resolved.items():
+            self.registry = self.registry.with_resource(
+                "memory:" + uri,
+                referencing.Resource.from_contents(contents, specification_uri),
+            )
+
+        if "$schema" not in self.schema:
+            warnings.warn("Schema version not specified. Defaulting to draft4")
+            updated = {"$schema": specification_uri}
+            updated.update(self.schema)
+            self.schema = updated
+
+        schema = Resource.from_contents(self.schema)
+        if schema.id() is None:
+            warnings.warn("Schema id not specified. Defaulting to 'self'")
+            updated = {"$id": "self", "id": "self"}
+            updated.update(self.schema)
+            self.schema = updated
+            schema = Resource.from_contents(self.schema)
+
+        self.registry = self.registry.with_resource("", schema)
+        self.resolver = self.registry.resolver()
+
+        if specification_uri is not None:
+            validatorClass = jsonschema.validators.validator_for(
+                {"$schema": specification_uri}
+            )
+        else:
+            validatorClass = jsonschema.validators.validator_for(self.schema)
+
+        meta_validator = validatorClass(
+            validatorClass.META_SCHEMA, registry=self.registry
+        )
         meta_validator.validate(self.schema)
-        self.validator = validatorClass(self.schema, resolver=self.resolver)
+        self.validator = validatorClass(self.schema, registry=self.registry)
 
         self._classes = None
         self._resolved = None
@@ -84,9 +162,6 @@ class ObjectBuilder(object):
         if self._resolved is None:
             self._classes = self.build_classes()
         return self._resolved.get(uri, None)
-
-    def memory_resolver(self, uri):
-        return self.mem_resolved[uri[7:]]
 
     def relative_file_resolver(self, uri):
         path = os.path.join(self.basedir, uri[8:])
@@ -126,10 +201,11 @@ class ObjectBuilder(object):
         kw = {"strict": strict}
         builder = classbuilder.ClassBuilder(self.resolver)
         for nm, defn in six.iteritems(self.schema.get("definitions", {})):
-            uri = util.resolve_ref_uri(
-                self.resolver.resolution_scope, "#/definitions/" + nm
+            resolved = self.resolver.lookup("#/definitions/" + nm)
+            uri = python_jsonschema_objects.util.resolve_ref_uri(
+                self.resolver._base_uri, "#/definitions/" + nm
             )
-            builder.construct(uri, defn, **kw)
+            builder.construct(uri, resolved.contents, **kw)
 
         if standardize_names:
             name_transform = lambda t: inflection.camelize(

--- a/python_jsonschema_objects/__init__.py
+++ b/python_jsonschema_objects/__init__.py
@@ -7,12 +7,13 @@ import logging
 import os.path
 import warnings
 from typing import Optional
+import typing
 
 import inflection
 import jsonschema
 import referencing.jsonschema
 import referencing.retrieval
-import referencing.typing
+import referencing._core
 import six
 from referencing import Registry, Resource
 
@@ -36,8 +37,8 @@ SUPPORTED_VERSIONS = (
 class ObjectBuilder(object):
     def __init__(
         self,
-        schema_uri,
-        resolved={},
+        schema_uri: typing.Union[typing.AnyStr, typing.Mapping],
+        resolved: typing.Dict[typing.AnyStr, typing.Mapping] = {},
         registry: Optional[referencing.Registry] = None,
         resolver: Optional[referencing.typing.Retrieve] = None,
         specification_uri: Optional[str] = None,
@@ -116,7 +117,6 @@ class ObjectBuilder(object):
             schema = Resource.from_contents(self.schema)
 
         self.registry = self.registry.with_resource("", schema)
-        self.resolver = self.registry.resolver()
 
         if len(resolved) > 0:
             warnings.warn(
@@ -144,6 +144,10 @@ class ObjectBuilder(object):
 
         self._classes = None
         self._resolved = None
+
+    @property
+    def resolver(self) -> referencing._core.Resolver:
+        return self.registry.resolver()
 
     @property
     def schema(self):

--- a/python_jsonschema_objects/__init__.py
+++ b/python_jsonschema_objects/__init__.py
@@ -6,22 +6,20 @@ import json
 import logging
 import os.path
 import warnings
+from typing import Optional
 
 import inflection
 import jsonschema
+import referencing.jsonschema
+import referencing.retrieval
+import referencing.typing
 import six
+from referencing import Registry, Resource
+
 import python_jsonschema_objects.classbuilder as classbuilder
 import python_jsonschema_objects.markdown_support
 import python_jsonschema_objects.util
 from python_jsonschema_objects.validators import ValidationError
-from typing import Optional
-
-from jsonschema_specifications import REGISTRY as SPECIFICATIONS
-from referencing import Registry, Resource
-import referencing.typing
-import referencing.jsonschema
-import referencing.retrieval
-
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +69,8 @@ class ObjectBuilder(object):
 
             if resolver is not None:
                 raise AttributeError(
-                    "Cannot specify both registry and resolver. If you provide your own registry, pass the resolver directly to that"
+                    "Cannot specify both registry and resolver. If you provide your own registry, pass the resolver "
+                    "directly to that"
                 )
             self.registry = registry
         else:
@@ -228,7 +227,7 @@ class ObjectBuilder(object):
             elif not named_only:
                 classes[name_transform(uri.split("/")[-1])] = klass
 
-        return util.Namespace.from_mapping(classes)
+        return python_jsonschema_objects.util.Namespace.from_mapping(classes)
 
 
 if __name__ == "__main__":

--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -1,3 +1,10 @@
+import referencing._core
+
+import python_jsonschema_objects.util as util
+import python_jsonschema_objects.validators as validators
+import python_jsonschema_objects.pattern_properties as pattern_properties
+from python_jsonschema_objects.literals import LiteralValue
+
 import collections
 import copy
 import itertools
@@ -443,7 +450,7 @@ class TypeProxy(object):
 
 
 class ClassBuilder(object):
-    def __init__(self, resolver):
+    def __init__(self, resolver: referencing._core.Resolver):
         self.resolver = resolver
         self.resolved = {}
         self.under_construction = set()
@@ -462,10 +469,8 @@ class ClassBuilder(object):
         return pp
 
     def resolve_type(self, ref, source):
-        """Return a resolved type for a URI, potentially constructing one if
-        necessary.
-        """
-        uri = util.resolve_ref_uri(self.resolver.resolution_scope, ref)
+        """Return a resolved type for a URI, potentially constructing one if necessary"""
+        uri = util.resolve_ref_uri(self.resolver._base_uri, ref)
         if uri in self.resolved:
             return self.resolved[uri]
 
@@ -484,9 +489,9 @@ class ClassBuilder(object):
                     "Resolving direct reference object {0} -> {1}", source, uri
                 )
             )
-            with self.resolver.resolving(ref) as resolved:
-                self.resolved[uri] = self.construct(uri, resolved, (ProtocolBase,))
-                return self.resolved[uri]
+            resolved = self.resolver.lookup(ref)
+            self.resolved[uri] = self.construct(uri, resolved.contents, (ProtocolBase,))
+            return self.resolved[uri]
 
     def construct(self, uri, *args, **kw):
         """Wrapper to debug things"""

--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -1,16 +1,10 @@
-import referencing._core
-
-import python_jsonschema_objects.util as util
-import python_jsonschema_objects.validators as validators
-import python_jsonschema_objects.pattern_properties as pattern_properties
-from python_jsonschema_objects.literals import LiteralValue
-
-import collections
+import collections.abc
 import copy
 import itertools
 import logging
 import sys
 
+import referencing._core
 import six
 
 from python_jsonschema_objects import (

--- a/python_jsonschema_objects/examples/README.md
+++ b/python_jsonschema_objects/examples/README.md
@@ -219,7 +219,7 @@ The schema and code example below show how this works.
 
 The `$ref` operator is supported in nearly all locations, and
 dispatches the actual reference resolution to the
-`jsonschema.RefResolver`.
+`referencing.Registry` resolver.
 
 This example shows using the memory URI (described in more detail
 below) to create a wrapper object that is just a string literal.
@@ -297,6 +297,9 @@ ValidationError: '[u'author']' are required attributes for B
 ```
 
 #### The "memory:" URI
+
+**"memory:" URIs are deprecated (although they still work). Load resources into a
+`referencing.Registry` instead and pass those in**
 
 The ObjectBuilder can be passed a dictionary specifying
 'memory' schemas when instantiated. This will allow it to

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
         install_requires=[
             "inflection>=0.2",
             "Markdown>=2.4",
-            "jsonschema>=2.3",
+            "jsonschema>=4.18",
             "six>=1.5.2",
         ],
         cmdclass=versioneer.get_cmdclass(),

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
         install_requires=[
             "inflection>=0.2",
             "Markdown>=2.4",
-            "jsonschema>=2.3,<4.18",
+            "jsonschema>=2.3",
             "six>=1.5.2",
         ],
         cmdclass=versioneer.get_cmdclass(),

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ if __name__ == "__main__":
         cmdclass=versioneer.get_cmdclass(),
         classifiers=[
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ if __name__ == "__main__":
             "jsonschema>=4.18",
             "six>=1.5.2",
         ],
+        python_requires=">=3.8",
         cmdclass=versioneer.get_cmdclass(),
         classifiers=[
             "Programming Language :: Python :: 3",

--- a/test/test_nondefault_resolver_validator.py
+++ b/test/test_nondefault_resolver_validator.py
@@ -1,8 +1,8 @@
 import pytest  # noqa
 import referencing
-import json
-import referencing.jsonschema
 import referencing.exceptions
+import referencing.jsonschema
+
 import python_jsonschema_objects as pjo
 
 

--- a/test/test_nondefault_resolver_validator.py
+++ b/test/test_nondefault_resolver_validator.py
@@ -1,24 +1,52 @@
-from jsonschema import Draft3Validator, RefResolver
-from jsonschema._utils import URIDict, load_schema
-
+import pytest  # noqa
+import referencing
+import json
+import referencing.jsonschema
+import referencing.exceptions
 import python_jsonschema_objects as pjo
 
 
-def test_non_default_resolver_validator(markdown_examples):
-    ms = URIDict()
-    draft3 = load_schema("draft3")
-    draft4 = load_schema("draft4")
-    ms[draft3["id"]] = draft3
-    ms[draft4["id"]] = draft4
-    resolver_with_store = RefResolver(draft3["id"], draft3, ms)
-
-    # 'Other' schema should be valid with draft3
+def test_custom_spec_validator(markdown_examples):
+    # This schema shouldn't be valid under DRAFT-03
+    schema = {
+        "$schema": "http://json-schema.org/draft-04/schema",
+        "title": "other",
+        "oneOf": [{"type": "string"}, {"type": "number"}],
+    }
     builder = pjo.ObjectBuilder(
-        markdown_examples["Other"],
-        resolver=resolver_with_store,
-        validatorClass=Draft3Validator,
+        schema,
+        specification_uri="http://json-schema.org/draft-03/schema",
         resolved=markdown_examples,
     )
     klasses = builder.build_classes()
-    a = klasses.Other(MyAddress="where I live")
-    assert a.MyAddress == "where I live"
+    a = klasses.Other("foo")
+    assert a == "foo"
+
+
+def test_non_default_resolver_finds_refs():
+    registry = referencing.Registry()
+
+    remote_schema = {
+        "$schema": "http://json-schema.org/draft-04/schema",
+        "type": "number",
+    }
+    registry = registry.with_resource(
+        "https://example.org/schema/example",
+        referencing.Resource.from_contents(remote_schema),
+    )
+
+    schema = {
+        "$schema": "http://json-schema.org/draft-04/schema",
+        "title": "other",
+        "type": "object",
+        "properties": {
+            "local": {"type": "string"},
+            "remote": {"$ref": "https://example.org/schema/example"},
+        },
+    }
+
+    builder = pjo.ObjectBuilder(
+        schema,
+        registry=registry,
+    )
+    builder.build_classes()

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -1,7 +1,4 @@
 import json
-
-import referencing.jsonschema
-import six
 import logging
 import warnings
 
@@ -30,8 +27,8 @@ def test_warnings_on_schema_version(version, warn, error):
     with warnings.catch_warnings(record=True) as w:
         try:
             pjs.ObjectBuilder(schema)
-        except Exception as e:
-            assert error == True
+        except Exception:
+            assert error == True  # noqa
         else:
             warn_msgs = [str(m.message) for m in w]
             present = [

--- a/test/test_regression_232.py
+++ b/test/test_regression_232.py
@@ -71,15 +71,9 @@ def test_nested_oneof_with_different_types(schema_json):
     builder = pjo.ObjectBuilder(schema_json)
     ns = builder.build_classes()
 
-    resolver = jsonschema.RefResolver.from_schema(schema_json)
-    main_obj = schema_json["definitions"]["MainObject"]
-
     test1 = {"location": 12345}
     test2 = {"location": {"type": "Location"}}
     test3 = {"location": "unique:12"}
-    jsonschema.validate(test1, main_obj, resolver=resolver)
-    jsonschema.validate(test2, main_obj, resolver=resolver)
-    jsonschema.validate(test3, main_obj, resolver=resolver)
 
     obj1 = ns.MainObject(**test1)
     obj2 = ns.MainObject(**test2)
@@ -94,13 +88,8 @@ def test_nested_oneof_with_different_types_by_reference(schema_json):
     builder = pjo.ObjectBuilder(schema_json)
     ns = builder.build_classes()
 
-    resolver = jsonschema.RefResolver.from_schema(schema_json)
-    ref_obj = schema_json["definitions"]["RefObject"]
-
     test1 = {"location": 12345}
     test2 = {"location": {"type": "Location"}}
-    jsonschema.validate(test1, ref_obj, resolver=resolver)
-    jsonschema.validate(test2, ref_obj, resolver=resolver)
 
     obj1 = ns.RefObject(**test1)
     obj2 = ns.RefObject(**test2)
@@ -113,15 +102,10 @@ def test_nested_oneof_with_different_types_in_additional_properties(schema_json)
     builder = pjo.ObjectBuilder(schema_json)
     ns = builder.build_classes()
 
-    resolver = jsonschema.RefResolver.from_schema(schema_json)
-    map_obj = schema_json["definitions"]["MapObject"]
-
     x_prop_name = "location-id"
 
     test1 = {x_prop_name: 12345}
     test2 = {x_prop_name: {"type": "Location"}}
-    jsonschema.validate(test1, map_obj, resolver=resolver)
-    jsonschema.validate(test2, map_obj, resolver=resolver)
 
     obj1 = ns.MapObject(**test1)
     obj2 = ns.MapObject(**test2)

--- a/test/test_regression_232.py
+++ b/test/test_regression_232.py
@@ -1,4 +1,3 @@
-import jsonschema
 import pytest
 
 import python_jsonschema_objects as pjo

--- a/test/thing-one.json
+++ b/test/thing-one.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "thing_one",
   "title": "thing_one",
   "description": "The first thing.",

--- a/test/thing-two.json
+++ b/test/thing-two.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "thing_two",
   "title": "thing_two",
   "description": "The second thing.",

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py{37,38,39,310,311,312}-jsonschema{40}-markdown{2,3}
+envlist = py{38,39,310,311,312}-jsonschema{40}-markdown{2,3}
 skip_missing_interpreters = true
 
 [gh-actions]
 python =
-  3.7: py37
   3.8: py38
   3.9: py39
   3.10: py310

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311,312}-jsonschema{23,24,25,26,30,40}-markdown{2,3}
+envlist = py{37,38,39,310,311,312}-jsonschema{40}-markdown{2,3}
 skip_missing_interpreters = true
 
 [gh-actions]
@@ -19,11 +19,6 @@ deps =
   coverage
   pytest
   pytest-mock
-  jsonschema23: jsonschema~=2.3.0
-  jsonschema24: jsonschema~=2.4.0
-  jsonschema25: jsonschema~=2.5.0
-  jsonschema26: jsonschema~=2.6.0
-  jsonschema30: jsonschema~=3.0.0
-  jsonschema40: jsonschema~=4.0
+  jsonschema40: jsonschema>=4.18
   markdown2: Markdown~=2.4
   markdown3: Markdown~=3.0


### PR DESCRIPTION
This adds support for jsonschema >4.18, but breaks support below that because of the breaking changes in that library.