### PR TITLE
Fix name tranfsorm

### DIFF
--- a/python_jsonschema_objects/__init__.py
+++ b/python_jsonschema_objects/__init__.py
@@ -225,9 +225,7 @@ class ObjectBuilder(object):
             builder.construct(uri, resolved.contents, **kw)
 
         if standardize_names:
-            name_transform = lambda t: inflection.camelize(
-                inflection.parameterize(six.text_type(t), "_")
-            )
+            name_transform = lambda t: inflection.camelize(six.text_type(t).replace(" ", "_").replace("-", "_").replace(".", "_"))
         else:
             name_transform = lambda t: t
 


### PR DESCRIPTION
Fix #271 


Before:
```
name_transform("hello world")  # Output: "HelloWorld"
name_transform("hello_world")  # Output: "HelloWorld"
name_transform("HelloWorld")   # Output: "Helloworld" <------ Bad :/
name_transform("hello-world")  # Output: "HelloWorld"
name_transform("hello.world")  # Output: "HelloWorld"
```
After:
```
name_transform("hello world")  # Output: "HelloWorld"
name_transform("hello_world")  # Output: "HelloWorld"
name_transform("HelloWorld")   # Output: "HelloWorld"
name_transform("hello-world")  # Output: "HelloWorld"
name_transform("hello.world")  # Output: "HelloWorld"
```
