### PR TITLE
Fix 0 default values appearing as None

### DIFF
--- a/python_jsonschema_objects/classbuilder.py
+++ b/python_jsonschema_objects/classbuilder.py
@@ -639,7 +639,7 @@ class ClassBuilder(object):
                 "__propinfo__": {
                     "__literal__": clsdata,
                     "__title__": clsdata.get("title"),
-                    "__default__": clsdata.get("default") or clsdata.get("const"),
+                    "__default__": clsdata["default"] if clsdata.get("default") is not None else clsdata.get("const"),
                 }
             },
         )


### PR DESCRIPTION
Consider the following json schema snippet to define a property:

```json
{
    "type" : "number",
    "minimum" : 0,
    "maximum" : 1,
    "default": 0
}
```

The code that sets the default reads:

```python
"__default__": clsdata.get("default") or clsdata.get("const"),
```

If the default is `0` as in the example above, then the right branch of the `or` will be selected and result to None.