### PR TITLE
Update README.md

### DIFF
--- a/python_jsonschema_objects/examples/README.md
+++ b/python_jsonschema_objects/examples/README.md
@@ -56,7 +56,7 @@ here that the schema above has been loaded in a variable called
 
 ``` python
 >>> import python_jsonschema_objects as pjs
->>> builder = pjs.ObjectBuilder(examples['Example Schema'])
+>>> builder = pjs.ObjectBuilder(examples)
 >>> ns = builder.build_classes()
 >>> Person = ns.ExampleSchema
 >>> james = Person(firstName="James", lastName="Bond")


### PR DESCRIPTION
updates readme. Seems like usage changed over the years from 
`builder = pjs.ObjectBuilder(examples['Example Schema'])`

to

`builder = pjs.ObjectBuilder(examples)`

The former gives the following error:

`KeyError                                  Traceback (most recent call last)
[<ipython-input-12-322e39d14e3a>](https://localhost:8080/#) in <cell line: 2>()
      1 import python_jsonschema_objects as pjs
----> 2 builder = pjs.ObjectBuilder(example["Example Schema"])
      3 ns = builder.build_classes()
      4 Person = ns.ExampleSchema
      5 james = Person(firstName="James", lastName="Bond")

KeyError: 'Example Schema'`